### PR TITLE
feat(core): implement AsyncLocalStorage-based request context with getContext()

### DIFF
--- a/packages/cli/src/server/createApp.ts
+++ b/packages/cli/src/server/createApp.ts
@@ -6,6 +6,7 @@
 
 import { Hono } from 'hono'
 import type { RouteManifest, CloudwerkConfig } from '@cloudwerk/core'
+import { contextMiddleware } from '@cloudwerk/core'
 import type { Logger, RegisteredRoute } from '../types.js'
 import { registerRoutes } from './registerRoutes.js'
 import { logRequest } from '../utils/logger.js'
@@ -39,6 +40,9 @@ export async function createApp(
   const app = new Hono({
     strict: false,
   })
+
+  // Add context middleware (MUST be first to capture all requests)
+  app.use('*', contextMiddleware())
 
   // Add request timing middleware for verbose mode
   if (verbose) {

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -1,0 +1,479 @@
+/**
+ * @cloudwerk/core - Context Tests
+ *
+ * Tests for AsyncLocalStorage-based request context.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import {
+  createContext,
+  getContext,
+  runWithContext,
+  contextMiddleware,
+} from '../context.js'
+import type { CloudwerkContext } from '../types.js'
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+/**
+ * Create a mock Hono context for testing.
+ */
+function createMockHonoContext(overrides: {
+  url?: string
+  method?: string
+  env?: Record<string, unknown>
+  executionCtx?: {
+    waitUntil: (promise: Promise<unknown>) => void
+    passThroughOnException: () => void
+  }
+} = {}) {
+  const url = overrides.url ?? 'https://example.com/test'
+  const method = overrides.method ?? 'GET'
+
+  return {
+    req: {
+      raw: new Request(url, { method }),
+      url,
+      method,
+    },
+    env: overrides.env ?? {},
+    executionCtx: overrides.executionCtx ?? {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+    },
+  } as unknown as import('hono').Context
+}
+
+// ============================================================================
+// Context Creation Tests
+// ============================================================================
+
+describe('createContext', () => {
+  it('should create context with request from Hono context', () => {
+    const honoCtx = createMockHonoContext({ url: 'https://example.com/api/users' })
+    const ctx = createContext(honoCtx)
+
+    expect(ctx.request).toBeInstanceOf(Request)
+    expect(ctx.request.url).toBe('https://example.com/api/users')
+  })
+
+  it('should create context with env from Hono context', () => {
+    const env = { DB: { query: vi.fn() }, KV: { get: vi.fn() } }
+    const honoCtx = createMockHonoContext({ env })
+    const ctx = createContext<typeof env>(honoCtx)
+
+    expect(ctx.env).toBe(env)
+    expect(ctx.env.DB).toBe(env.DB)
+    expect(ctx.env.KV).toBe(env.KV)
+  })
+
+  it('should create context with executionCtx from Hono context', () => {
+    const executionCtx = {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+    }
+    const honoCtx = createMockHonoContext({ executionCtx })
+    const ctx = createContext(honoCtx)
+
+    expect(ctx.executionCtx).toBe(executionCtx)
+  })
+
+  it('should generate unique requestId for each context', () => {
+    const honoCtx1 = createMockHonoContext()
+    const honoCtx2 = createMockHonoContext()
+
+    const ctx1 = createContext(honoCtx1)
+    const ctx2 = createContext(honoCtx2)
+
+    expect(ctx1.requestId).toBeDefined()
+    expect(ctx2.requestId).toBeDefined()
+    expect(ctx1.requestId).not.toBe(ctx2.requestId)
+    // Verify UUID format
+    expect(ctx1.requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+  })
+
+  it('should initialize params as empty object', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    expect(ctx.params).toEqual({})
+  })
+
+  it('should provide fallback executionCtx when not available', () => {
+    const honoCtx = createMockHonoContext()
+    // Simulate environment that throws when accessing executionCtx (like Hono in tests)
+    Object.defineProperty(honoCtx, 'executionCtx', {
+      get() {
+        throw new Error('This context has no ExecutionContext')
+      },
+    })
+
+    const ctx = createContext(honoCtx)
+
+    expect(ctx.executionCtx).toBeDefined()
+    expect(typeof ctx.executionCtx.waitUntil).toBe('function')
+    expect(typeof ctx.executionCtx.passThroughOnException).toBe('function')
+  })
+})
+
+// ============================================================================
+// Context get/set Tests
+// ============================================================================
+
+describe('context get/set', () => {
+  it('should store and retrieve values', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    ctx.set('userId', 123)
+    ctx.set('role', 'admin')
+
+    expect(ctx.get('userId')).toBe(123)
+    expect(ctx.get('role')).toBe('admin')
+  })
+
+  it('should return undefined for unset keys', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    expect(ctx.get('nonexistent')).toBeUndefined()
+  })
+
+  it('should support typed get', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    interface User {
+      id: number
+      name: string
+    }
+
+    ctx.set('user', { id: 1, name: 'Alice' })
+
+    const user = ctx.get<User>('user')
+    expect(user?.id).toBe(1)
+    expect(user?.name).toBe('Alice')
+  })
+
+  it('should overwrite existing values', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    ctx.set('count', 1)
+    ctx.set('count', 2)
+
+    expect(ctx.get('count')).toBe(2)
+  })
+
+  it('should isolate data between contexts', () => {
+    const honoCtx1 = createMockHonoContext()
+    const honoCtx2 = createMockHonoContext()
+
+    const ctx1 = createContext(honoCtx1)
+    const ctx2 = createContext(honoCtx2)
+
+    ctx1.set('value', 'from ctx1')
+    ctx2.set('value', 'from ctx2')
+
+    expect(ctx1.get('value')).toBe('from ctx1')
+    expect(ctx2.get('value')).toBe('from ctx2')
+  })
+})
+
+// ============================================================================
+// getContext Tests
+// ============================================================================
+
+describe('getContext', () => {
+  it('should throw descriptive error when called outside request', () => {
+    expect(() => getContext()).toThrow('getContext() called outside of request handler')
+    expect(() => getContext()).toThrow('nodejs_compat')
+  })
+
+  it('should return context when inside runWithContext', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    const result = runWithContext(ctx, () => {
+      const currentCtx = getContext()
+      return currentCtx.requestId
+    })
+
+    expect(result).toBe(ctx.requestId)
+  })
+
+  it('should return typed context with generic', () => {
+    interface MyEnv {
+      DB: { query: () => void }
+    }
+
+    const env = { DB: { query: vi.fn() } }
+    const honoCtx = createMockHonoContext({ env })
+    const ctx = createContext<MyEnv>(honoCtx)
+
+    runWithContext(ctx, () => {
+      const currentCtx = getContext<MyEnv>()
+      expect(currentCtx.env.DB.query).toBeDefined()
+    })
+  })
+})
+
+// ============================================================================
+// runWithContext Tests
+// ============================================================================
+
+describe('runWithContext', () => {
+  it('should execute function within context', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+    const fn = vi.fn(() => 42)
+
+    const result = runWithContext(ctx, fn)
+
+    expect(fn).toHaveBeenCalled()
+    expect(result).toBe(42)
+  })
+
+  it('should make context available to nested calls', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    function nestedFunction() {
+      return getContext().requestId
+    }
+
+    const result = runWithContext(ctx, () => {
+      return nestedFunction()
+    })
+
+    expect(result).toBe(ctx.requestId)
+  })
+
+  it('should handle async functions', async () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    const result = await runWithContext(ctx, async () => {
+      await new Promise(resolve => setTimeout(resolve, 10))
+      return getContext().requestId
+    })
+
+    expect(result).toBe(ctx.requestId)
+  })
+
+  it('should isolate concurrent requests', async () => {
+    const honoCtx1 = createMockHonoContext()
+    const honoCtx2 = createMockHonoContext()
+    const ctx1 = createContext(honoCtx1)
+    const ctx2 = createContext(honoCtx2)
+
+    ctx1.set('requestNumber', 1)
+    ctx2.set('requestNumber', 2)
+
+    // Simulate concurrent requests
+    const [result1, result2] = await Promise.all([
+      runWithContext(ctx1, async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        return getContext().get<number>('requestNumber')
+      }),
+      runWithContext(ctx2, async () => {
+        await new Promise(resolve => setTimeout(resolve, 10))
+        return getContext().get<number>('requestNumber')
+      }),
+    ])
+
+    expect(result1).toBe(1)
+    expect(result2).toBe(2)
+  })
+})
+
+// ============================================================================
+// contextMiddleware Tests
+// ============================================================================
+
+describe('contextMiddleware', () => {
+  it('should create middleware handler', () => {
+    const middleware = contextMiddleware()
+    expect(typeof middleware).toBe('function')
+  })
+
+  it('should make context available in handlers', async () => {
+    const app = new Hono()
+    let capturedCtx: CloudwerkContext | null = null
+
+    app.use('*', contextMiddleware())
+    app.get('/test', (c) => {
+      capturedCtx = getContext()
+      return c.json({ ok: true })
+    })
+
+    await app.request('/test')
+
+    expect(capturedCtx).not.toBeNull()
+    expect(capturedCtx!.requestId).toBeDefined()
+    expect(capturedCtx!.request.url).toContain('/test')
+  })
+
+  it('should pass env to context', async () => {
+    interface TestEnv {
+      API_KEY: string
+    }
+
+    const app = new Hono<{ Bindings: TestEnv }>()
+    let envValue: string | undefined
+
+    app.use('*', contextMiddleware())
+    app.get('/test', () => {
+      const ctx = getContext<TestEnv>()
+      envValue = ctx.env.API_KEY
+      return new Response('ok')
+    })
+
+    // Simulate request with bindings
+    await app.fetch(
+      new Request('http://localhost/test'),
+      { API_KEY: 'secret-key' }
+    )
+
+    expect(envValue).toBe('secret-key')
+  })
+
+  it('should allow middleware to set data accessible in handlers', async () => {
+    const app = new Hono()
+    let userData: unknown
+
+    app.use('*', contextMiddleware())
+
+    // Auth middleware that sets user data
+    app.use('*', async (c, next) => {
+      const ctx = getContext()
+      ctx.set('user', { id: 1, email: 'test@example.com' })
+      await next()
+    })
+
+    app.get('/profile', () => {
+      const ctx = getContext()
+      userData = ctx.get('user')
+      return new Response('ok')
+    })
+
+    await app.request('/profile')
+
+    expect(userData).toEqual({ id: 1, email: 'test@example.com' })
+  })
+
+  it('should isolate context between concurrent requests', async () => {
+    const app = new Hono()
+    const results: { id: number; value: number }[] = []
+
+    app.use('*', contextMiddleware())
+    app.use('*', async (c, next) => {
+      const id = Number(c.req.query('id') || 0)
+      const ctx = getContext()
+      ctx.set('requestId', id)
+      await next()
+    })
+
+    app.get('/test', async (c) => {
+      const ctx = getContext()
+      const id = ctx.get<number>('requestId') ?? 0
+
+      // Simulate async work that could cause context mixing
+      await new Promise(resolve => setTimeout(resolve, Math.random() * 20))
+
+      const value = ctx.get<number>('requestId') ?? 0
+      results.push({ id, value })
+
+      return c.json({ id, value })
+    })
+
+    // Fire 5 concurrent requests
+    await Promise.all([
+      app.request('/test?id=1'),
+      app.request('/test?id=2'),
+      app.request('/test?id=3'),
+      app.request('/test?id=4'),
+      app.request('/test?id=5'),
+    ])
+
+    // Each request should have its own isolated value
+    for (const result of results) {
+      expect(result.id).toBe(result.value)
+    }
+  })
+})
+
+// ============================================================================
+// TypeScript Generic Tests
+// ============================================================================
+
+describe('TypeScript generics', () => {
+  it('should type env correctly', () => {
+    interface CloudflareEnv {
+      DB: { prepare: (sql: string) => { all: () => unknown[] } }
+      KV: { get: (key: string) => Promise<string | null> }
+      R2: { get: (key: string) => Promise<unknown> }
+    }
+
+    const env: CloudflareEnv = {
+      DB: { prepare: () => ({ all: () => [] }) },
+      KV: { get: async () => null },
+      R2: { get: async () => null },
+    }
+
+    const honoCtx = createMockHonoContext({ env })
+    const ctx = createContext<CloudflareEnv>(honoCtx)
+
+    // TypeScript should recognize these as valid
+    expect(ctx.env.DB.prepare).toBeDefined()
+    expect(ctx.env.KV.get).toBeDefined()
+    expect(ctx.env.R2.get).toBeDefined()
+  })
+
+  it('should type get/set correctly', () => {
+    interface Session {
+      userId: string
+      role: 'admin' | 'user'
+    }
+
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    const session: Session = { userId: '123', role: 'admin' }
+    ctx.set<Session>('session', session)
+
+    const retrieved = ctx.get<Session>('session')
+    expect(retrieved?.userId).toBe('123')
+    expect(retrieved?.role).toBe('admin')
+  })
+})
+
+// ============================================================================
+// requestId Tests
+// ============================================================================
+
+describe('requestId', () => {
+  it('should be a valid UUID v4 format', () => {
+    const honoCtx = createMockHonoContext()
+    const ctx = createContext(honoCtx)
+
+    // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    expect(ctx.requestId).toMatch(uuidRegex)
+  })
+
+  it('should be unique across many contexts', () => {
+    const requestIds = new Set<string>()
+
+    for (let i = 0; i < 100; i++) {
+      const honoCtx = createMockHonoContext()
+      const ctx = createContext(honoCtx)
+      requestIds.add(ctx.requestId)
+    }
+
+    expect(requestIds.size).toBe(100)
+  })
+})

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,0 +1,169 @@
+/**
+ * @cloudwerk/core - Request Context
+ *
+ * AsyncLocalStorage-based request context for accessing Cloudflare bindings,
+ * middleware data, and execution context without explicit parameter passing.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { Context, MiddlewareHandler } from 'hono'
+import type { CloudwerkContext, ExecutionContext } from './types.js'
+
+// ============================================================================
+// Internal Context Storage
+// ============================================================================
+
+/**
+ * Internal AsyncLocalStorage instance for request-scoped context.
+ * This is not exported to prevent direct manipulation.
+ */
+const contextStorage = new AsyncLocalStorage<CloudwerkContext<unknown>>()
+
+// ============================================================================
+// Context Creation
+// ============================================================================
+
+/**
+ * Create a CloudwerkContext from a Hono context.
+ *
+ * @param honoContext - The Hono request context
+ * @returns A new CloudwerkContext instance
+ *
+ * @example
+ * const ctx = createContext<MyEnv>(c)
+ * ctx.env.DB // Access D1 binding
+ * ctx.request.url // Access request URL
+ */
+export function createContext<Env = Record<string, unknown>>(
+  honoContext: Context
+): CloudwerkContext<Env> {
+  // Internal data store for get/set operations
+  const dataStore = new Map<string, unknown>()
+
+  // Generate unique request ID for tracing
+  const requestId = crypto.randomUUID()
+
+  // Extract execution context from Hono (may throw in some environments)
+  let executionCtx: ExecutionContext
+  try {
+    executionCtx = honoContext.executionCtx
+  } catch {
+    // Fallback for environments without execution context (e.g., tests, non-Workers)
+    executionCtx = {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    }
+  }
+
+  return {
+    request: honoContext.req.raw,
+    env: honoContext.env as Env,
+    executionCtx,
+    params: {}, // Will be set by router when handling dynamic routes
+    requestId,
+
+    get<T>(key: string): T | undefined {
+      return dataStore.get(key) as T | undefined
+    },
+
+    set<T>(key: string, value: T): void {
+      dataStore.set(key, value)
+    },
+  }
+}
+
+// ============================================================================
+// Context Execution
+// ============================================================================
+
+/**
+ * Run a function within a request context.
+ *
+ * @param ctx - The CloudwerkContext to use
+ * @param fn - The function to execute within the context
+ * @returns The return value of the function
+ *
+ * @example
+ * const result = runWithContext(ctx, () => {
+ *   const currentCtx = getContext()
+ *   return currentCtx.env.DB.prepare('SELECT * FROM users').all()
+ * })
+ */
+export function runWithContext<T>(ctx: CloudwerkContext, fn: () => T): T {
+  return contextStorage.run(ctx, fn)
+}
+
+// ============================================================================
+// Context Access
+// ============================================================================
+
+/**
+ * Get the current request context.
+ *
+ * @returns The current CloudwerkContext
+ * @throws Error if called outside of a request handler
+ *
+ * @example
+ * // In a route handler:
+ * export function GET() {
+ *   const ctx = getContext<MyEnv>()
+ *   const db = ctx.env.DB
+ *   const userId = ctx.params.id
+ *   return json({ userId })
+ * }
+ *
+ * @example
+ * // In a service function:
+ * async function getCurrentUser() {
+ *   const { env, request } = getContext<MyEnv>()
+ *   const token = request.headers.get('Authorization')
+ *   return env.DB.prepare('SELECT * FROM users WHERE token = ?').bind(token).first()
+ * }
+ */
+export function getContext<Env = Record<string, unknown>>(): CloudwerkContext<Env> {
+  const ctx = contextStorage.getStore()
+
+  if (!ctx) {
+    throw new Error(
+      `getContext() called outside of request handler.
+
+This function can only be used during request handling within a Cloudwerk application.
+If you're seeing this error on Cloudflare Workers, ensure nodejs_compat is enabled:
+
+  # wrangler.toml
+  compatibility_flags = ["nodejs_compat"]`
+    )
+  }
+
+  return ctx as CloudwerkContext<Env>
+}
+
+// ============================================================================
+// Context Middleware
+// ============================================================================
+
+/**
+ * Hono middleware that creates and wraps requests with CloudwerkContext.
+ *
+ * This middleware should be applied first in the middleware chain to ensure
+ * all subsequent handlers have access to the context.
+ *
+ * @returns Hono middleware handler
+ *
+ * @example
+ * import { Hono } from 'hono'
+ * import { contextMiddleware } from '@cloudwerk/core'
+ *
+ * const app = new Hono()
+ * app.use('*', contextMiddleware())
+ */
+export function contextMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const ctx = createContext(c)
+
+    // Run the rest of the middleware chain within the context
+    return runWithContext(ctx, async () => {
+      await next()
+    })
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,10 @@ export type {
   PageComponent,
   LayoutComponent,
 
+  // Context Types
+  CloudwerkContext,
+  ExecutionContext,
+
   // Scanner Types
   ScannedFile,
   ScanResult,
@@ -161,6 +165,20 @@ export {
   resolveRoutesDir,
   isSupportedExtension,
 } from './config.js'
+
+// ============================================================================
+// Context Exports
+// ============================================================================
+
+export {
+  // Context Access
+  getContext,
+
+  // Internal (for middleware integration)
+  runWithContext,
+  createContext,
+  contextMiddleware,
+} from './context.js'
 
 // ============================================================================
 // Response Helper Exports

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -268,6 +268,44 @@ export type LayoutComponent<TParams = Record<string, string>> = (
 ) => unknown | Promise<unknown>
 
 // ============================================================================
+// Context Types
+// ============================================================================
+
+/**
+ * Cloudflare Workers execution context
+ */
+export interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void
+  passThroughOnException(): void
+}
+
+/**
+ * Request-scoped context accessible via getContext()
+ */
+export interface CloudwerkContext<Env = Record<string, unknown>> {
+  /** Original request object */
+  request: Request
+
+  /** Cloudflare bindings (D1, KV, R2, etc.) */
+  env: Env
+
+  /** Cloudflare execution context for waitUntil */
+  executionCtx: ExecutionContext
+
+  /** Route parameters from dynamic segments */
+  params: Record<string, string>
+
+  /** Auto-generated request ID for tracing */
+  requestId: string
+
+  /** Get middleware-set data */
+  get<T>(key: string): T | undefined
+
+  /** Set data for downstream code */
+  set<T>(key: string, value: T): void
+}
+
+// ============================================================================
 // Scanner Types
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Implements a request-scoped context system using `AsyncLocalStorage` that allows route handlers and any downstream code to access Cloudflare bindings, middleware data, and execution context without explicitly passing parameters through function chains.

- Add `getContext<Env>()` function for accessing request context anywhere
- Add `CloudwerkContext<Env>` interface with typed `env`, `executionCtx`, `get/set`
- Integrate context middleware into CLI dev server as first middleware
- Comprehensive test suite (27 tests) with concurrent request isolation tests

## Changes

### New Files
- `packages/core/src/context.ts` - AsyncLocalStorage implementation (170 LOC)
- `packages/core/src/__tests__/context.test.ts` - Test suite (480 LOC, 27 tests)

### Modified Files
- `packages/core/src/types.ts` - Added `CloudwerkContext` and `ExecutionContext` interfaces
- `packages/core/src/index.ts` - Export context types and functions
- `packages/cli/src/server/createApp.ts` - Add `contextMiddleware()` as first middleware

## API Example

```typescript
import { getContext } from '@cloudwerk/core'

export async function GET(request: Request) {
  const ctx = getContext<MyEnv>()
  
  // Cloudflare bindings (typed)
  const db = ctx.env.DB           // D1Database
  const kv = ctx.env.KV           // KVNamespace
  
  // Request metadata
  const requestId = ctx.requestId // Auto-generated UUID
  
  // Middleware data
  const user = ctx.get('user')    // Set by auth middleware
  
  // Execution context
  ctx.executionCtx.waitUntil(analytics.track('page_view'))
  
  return json({ user })
}
```

## Test Plan

- [x] Build passes (`npm run build`)
- [x] All 290 tests pass (`npm test`)
- [x] TypeScript type check passes
- [x] Linting passes (`npm run lint`)
- [x] Context isolation verified with concurrent request tests
- [x] Descriptive error thrown when `getContext()` called outside request

## Related Issues

Closes #25

## Checklist

- [x] Tests added/updated
- [x] Documentation in JSDoc comments
- [x] No secrets committed
- [x] All quality gates passed