### PR TITLE
feat(core): implement Cloudwerk-native route handler signature

### DIFF
--- a/packages/cli/__fixtures__/with-dynamic-routes/app/api/users/[id]/route.ts
+++ b/packages/cli/__fixtures__/with-dynamic-routes/app/api/users/[id]/route.ts
@@ -1,8 +1,13 @@
 /**
- * Single user route for testing dynamic routes.
+ * Single user route demonstrating Cloudwerk-native handler signature.
  */
 
-import type { Context } from 'hono'
+import { json, notFound, noContent } from '@cloudwerk/core'
+import type { CloudwerkHandler } from '@cloudwerk/core'
+
+interface Params {
+  id: string
+}
 
 const users = [
   { id: '1', name: 'Alice', email: 'alice@example.com' },
@@ -10,40 +15,37 @@ const users = [
   { id: '3', name: 'Charlie', email: 'charlie@example.com' },
 ]
 
-export const GET = (c: Context) => {
-  const id = c.req.param('id')
-  const user = users.find((u) => u.id === id)
+export const GET: CloudwerkHandler<Params> = (request, { params }) => {
+  const user = users.find((u) => u.id === params.id)
 
   if (!user) {
-    return c.json({ error: 'User not found' }, 404)
+    return notFound('User not found')
   }
 
-  return c.json({ user })
+  return json({ user })
 }
 
-export const PUT = async (c: Context) => {
-  const id = c.req.param('id')
-  const index = users.findIndex((u) => u.id === id)
+export const PUT: CloudwerkHandler<Params> = async (request, { params }) => {
+  const index = users.findIndex((u) => u.id === params.id)
 
   if (index === -1) {
-    return c.json({ error: 'User not found' }, 404)
+    return notFound('User not found')
   }
 
-  const body = await c.req.json()
+  const body = await request.json()
   users[index] = { ...users[index], ...body }
 
-  return c.json({ user: users[index] })
+  return json({ user: users[index] })
 }
 
-export const DELETE = (c: Context) => {
-  const id = c.req.param('id')
-  const index = users.findIndex((u) => u.id === id)
+export const DELETE: CloudwerkHandler<Params> = (request, { params }) => {
+  const index = users.findIndex((u) => u.id === params.id)
 
   if (index === -1) {
-    return c.json({ error: 'User not found' }, 404)
+    return notFound('User not found')
   }
 
   users.splice(index, 1)
 
-  return new Response(null, { status: 204 })
+  return noContent()
 }

--- a/packages/cli/src/__tests__/loadHandler.test.ts
+++ b/packages/cli/src/__tests__/loadHandler.test.ts
@@ -69,24 +69,16 @@ describe('loadRouteHandler', () => {
       expect(module.POST).toBeUndefined()
     })
 
-    it('should execute GET handler with param extraction', async () => {
+    it('should execute GET handler with param extraction (Cloudwerk signature)', async () => {
       const routePath = path.join(FIXTURES_DIR, 'with-dynamic-routes/app/api/users/[id]/route.ts')
       const module = await loadRouteHandler(routePath)
 
-      // Create a mock context with param method
-      const mockContext = {
-        req: {
-          param: (name: string) => name === 'id' ? '1' : undefined,
-        },
-        json: (data: unknown, status?: number) => {
-          return new Response(JSON.stringify(data), {
-            status: status ?? 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
-        },
-      }
+      // This fixture uses the Cloudwerk-native handler signature (arity 2)
+      // Handler signature: (request: Request, context: { params }) => Response
+      const request = new Request('http://localhost/api/users/1')
+      const context = { params: { id: '1' } }
 
-      const response = await module.GET!(mockContext)
+      const response = await module.GET!(request, context)
       expect(response).toBeInstanceOf(Response)
       expect(response.status).toBe(200)
 
@@ -96,24 +88,15 @@ describe('loadRouteHandler', () => {
       expect(data.user.name).toBe('Alice')
     })
 
-    it('should return 404 for non-existent user', async () => {
+    it('should return 404 for non-existent user (Cloudwerk signature)', async () => {
       const routePath = path.join(FIXTURES_DIR, 'with-dynamic-routes/app/api/users/[id]/route.ts')
       const module = await loadRouteHandler(routePath)
 
-      // Create a mock context with non-existent ID
-      const mockContext = {
-        req: {
-          param: (name: string) => name === 'id' ? '999' : undefined,
-        },
-        json: (data: unknown, status?: number) => {
-          return new Response(JSON.stringify(data), {
-            status: status ?? 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
-        },
-      }
+      // This fixture uses the Cloudwerk-native handler signature (arity 2)
+      const request = new Request('http://localhost/api/users/999')
+      const context = { params: { id: '999' } }
 
-      const response = await module.GET!(mockContext)
+      const response = await module.GET!(request, context)
       expect(response.status).toBe(404)
 
       const data = await response.json()

--- a/packages/core/src/__tests__/handler-signature.test.ts
+++ b/packages/core/src/__tests__/handler-signature.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for Cloudwerk-native handler signature types and detection.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { CloudwerkHandler, CloudwerkHandlerContext } from '../types.js'
+import { getContext, runWithContext, createContext } from '../context.js'
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+/**
+ * Create a mock Hono context for testing.
+ */
+function createMockHonoContext(overrides: {
+  url?: string
+  method?: string
+  env?: Record<string, unknown>
+  executionCtx?: {
+    waitUntil: (promise: Promise<unknown>) => void
+    passThroughOnException: () => void
+  }
+} = {}) {
+  const url = overrides.url ?? 'https://example.com/test'
+  const method = overrides.method ?? 'GET'
+
+  return {
+    req: {
+      raw: new Request(url, { method }),
+      url,
+      method,
+      param: () => ({}),
+    },
+    env: overrides.env ?? {},
+    executionCtx: overrides.executionCtx ?? {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+    },
+  } as unknown as import('hono').Context
+}
+
+// ============================================================================
+// CloudwerkHandler Type Tests
+// ============================================================================
+
+describe('CloudwerkHandler type', () => {
+  describe('handler signature detection', () => {
+    it('detects Cloudwerk handler by arity 2', () => {
+      const cloudwerkHandler: CloudwerkHandler = (request, context) => {
+        return new Response('ok')
+      }
+
+      expect(cloudwerkHandler.length).toBe(2)
+    })
+
+    it('detects legacy Hono handler by arity 1', () => {
+      const honoHandler = (c: unknown) => {
+        return new Response('ok')
+      }
+
+      expect(honoHandler.length).toBe(1)
+    })
+  })
+
+  describe('params flow', () => {
+    it('context.params contains route parameters', () => {
+      const handler: CloudwerkHandler<{ id: string }> = (request, { params }) => {
+        expect(params.id).toBe('123')
+        return new Response('ok')
+      }
+
+      const request = new Request('http://example.com/users/123')
+      handler(request, { params: { id: '123' } })
+    })
+
+    it('getContext().params matches context.params after assignment', () => {
+      const mockHonoContext = createMockHonoContext({
+        url: 'http://example.com/users/123',
+      })
+
+      const ctx = createContext(mockHonoContext)
+
+      runWithContext(ctx, () => {
+        // Simulate what wrapCloudwerkHandler does
+        const params = { id: '123' }
+        Object.assign(ctx.params, params)
+
+        // Verify getContext().params matches
+        const currentCtx = getContext()
+        expect(currentCtx.params).toEqual({ id: '123' })
+      })
+    })
+  })
+
+  describe('type safety', () => {
+    it('CloudwerkHandlerContext accepts typed params', () => {
+      interface UserParams {
+        userId: string
+        postId: string
+      }
+
+      const context: CloudwerkHandlerContext<UserParams> = {
+        params: { userId: '1', postId: '2' }
+      }
+
+      expect(context.params.userId).toBe('1')
+      expect(context.params.postId).toBe('2')
+    })
+
+    it('CloudwerkHandler enforces return type', () => {
+      // This should compile - returns Response
+      const validHandler: CloudwerkHandler = () => new Response('ok')
+
+      // This should compile - returns Promise<Response>
+      const asyncHandler: CloudwerkHandler = async () => new Response('ok')
+
+      expect(validHandler(new Request('http://example.com'), { params: {} })).toBeInstanceOf(Response)
+    })
+  })
+
+  describe('concurrent request isolation', () => {
+    it('params are isolated between concurrent requests', async () => {
+      const mockHonoContext1 = createMockHonoContext({
+        url: 'http://example.com/users/1',
+      })
+
+      const mockHonoContext2 = createMockHonoContext({
+        url: 'http://example.com/users/2',
+      })
+
+      const ctx1 = createContext(mockHonoContext1)
+      const ctx2 = createContext(mockHonoContext2)
+
+      // Simulate concurrent requests
+      const results = await Promise.all([
+        runWithContext(ctx1, async () => {
+          Object.assign(ctx1.params, { id: '1' })
+          // Small delay to interleave with other request
+          await new Promise(resolve => setTimeout(resolve, 10))
+          return getContext().params.id
+        }),
+        runWithContext(ctx2, async () => {
+          Object.assign(ctx2.params, { id: '2' })
+          await new Promise(resolve => setTimeout(resolve, 5))
+          return getContext().params.id
+        }),
+      ])
+
+      expect(results).toEqual(['1', '2'])
+    })
+  })
+})
+
+// ============================================================================
+// Handler Signature Behavior Tests
+// ============================================================================
+
+describe('handler signature behavior', () => {
+  it('Cloudwerk handler receives standard Request object', () => {
+    const handler: CloudwerkHandler = (request, context) => {
+      expect(request).toBeInstanceOf(Request)
+      expect(request.url).toBe('http://example.com/api/users')
+      return new Response('ok')
+    }
+
+    const request = new Request('http://example.com/api/users')
+    handler(request, { params: {} })
+  })
+
+  it('Cloudwerk handler can read request body', async () => {
+    const handler: CloudwerkHandler = async (request, context) => {
+      const body = await request.json()
+      expect(body).toEqual({ name: 'Alice' })
+      return new Response('ok')
+    }
+
+    const request = new Request('http://example.com/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice' }),
+    })
+
+    await handler(request, { params: {} })
+  })
+
+  it('Cloudwerk handler can read request headers', () => {
+    const handler: CloudwerkHandler = (request, context) => {
+      const authHeader = request.headers.get('Authorization')
+      expect(authHeader).toBe('Bearer token123')
+      return new Response('ok')
+    }
+
+    const request = new Request('http://example.com/api/users', {
+      headers: { 'Authorization': 'Bearer token123' },
+    })
+
+    handler(request, { params: {} })
+  })
+
+  it('Cloudwerk handler can access params from context', () => {
+    interface Params {
+      userId: string
+      postId: string
+    }
+
+    const handler: CloudwerkHandler<Params> = (request, { params }) => {
+      expect(params.userId).toBe('123')
+      expect(params.postId).toBe('456')
+      return new Response('ok')
+    }
+
+    const request = new Request('http://example.com/api/users/123/posts/456')
+    handler(request, { params: { userId: '123', postId: '456' } })
+  })
+})
+
+// ============================================================================
+// Integration with getContext Tests
+// ============================================================================
+
+describe('integration with getContext', () => {
+  it('handler can access env via getContext()', () => {
+    interface TestEnv {
+      API_KEY: string
+    }
+
+    const mockHonoContext = createMockHonoContext({
+      env: { API_KEY: 'secret-key' },
+    })
+
+    const ctx = createContext<TestEnv>(mockHonoContext)
+
+    const handler: CloudwerkHandler = (request, context) => {
+      const { env } = getContext<TestEnv>()
+      expect(env.API_KEY).toBe('secret-key')
+      return new Response('ok')
+    }
+
+    runWithContext(ctx, () => {
+      handler(new Request('http://example.com'), { params: {} })
+    })
+  })
+
+  it('handler can access requestId via getContext()', () => {
+    const mockHonoContext = createMockHonoContext()
+    const ctx = createContext(mockHonoContext)
+
+    let capturedRequestId: string | undefined
+
+    const handler: CloudwerkHandler = (request, context) => {
+      capturedRequestId = getContext().requestId
+      return new Response('ok')
+    }
+
+    runWithContext(ctx, () => {
+      handler(new Request('http://example.com'), { params: {} })
+    })
+
+    expect(capturedRequestId).toBe(ctx.requestId)
+  })
+
+  it('handler can use get/set via getContext()', () => {
+    const mockHonoContext = createMockHonoContext()
+    const ctx = createContext(mockHonoContext)
+
+    // Simulate middleware setting data
+    ctx.set('user', { id: 1, name: 'Alice' })
+
+    const handler: CloudwerkHandler = (request, context) => {
+      const user = getContext().get<{ id: number; name: string }>('user')
+      expect(user).toEqual({ id: 1, name: 'Alice' })
+      return new Response('ok')
+    }
+
+    runWithContext(ctx, () => {
+      handler(new Request('http://example.com'), { params: {} })
+    })
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,10 @@ export type {
   PageComponent,
   LayoutComponent,
 
+  // Cloudwerk Native Handler Types
+  CloudwerkHandler,
+  CloudwerkHandlerContext,
+
   // Context Types
   CloudwerkContext,
   ExecutionContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -239,6 +239,8 @@ export interface LayoutProps<TParams = Record<string, string>> {
 
 /**
  * Route handler context (extends Hono context)
+ * @deprecated Use CloudwerkHandlerContext with CloudwerkHandler instead.
+ * This type will be removed in a future version.
  */
 export type RouteContext<TParams = Record<string, string>> = Context & {
   req: {
@@ -248,9 +250,56 @@ export type RouteContext<TParams = Record<string, string>> = Context & {
 
 /**
  * Route handler function signature
+ * @deprecated Use CloudwerkHandler instead, which provides a cleaner signature:
+ * `(request: Request, context: CloudwerkHandlerContext) => Response`
+ * This type will be removed in a future version.
  */
 export type RouteHandler<TParams = Record<string, string>> = (
   c: RouteContext<TParams>
+) => Response | Promise<Response>
+
+// ============================================================================
+// Cloudwerk Native Handler Types
+// ============================================================================
+
+/**
+ * Handler context passed directly to route handlers.
+ * Use getContext() for full context including env and executionCtx.
+ */
+export interface CloudwerkHandlerContext<TParams = Record<string, string>> {
+  /** Route parameters from dynamic segments */
+  params: TParams
+}
+
+/**
+ * Cloudwerk-native route handler signature.
+ *
+ * **Important**: Both parameters must be declared for automatic detection.
+ * Use `_context` if the context parameter is unused.
+ *
+ * @example
+ * // With params
+ * export function GET(request: Request, { params }: CloudwerkHandlerContext<{ id: string }>) {
+ *   return json({ userId: params.id })
+ * }
+ *
+ * @example
+ * // Without params (still need second parameter for detection)
+ * export function GET(request: Request, _context: CloudwerkHandlerContext) {
+ *   return new Response('Hello Cloudwerk')
+ * }
+ *
+ * @example
+ * // Accessing env and request together
+ * export function GET(request: Request, context: CloudwerkHandlerContext<{ id: string }>) {
+ *   const { id } = context.params
+ *   const { env } = getContext<MyEnv>()
+ *   return json({ userId: id })
+ * }
+ */
+export type CloudwerkHandler<TParams = Record<string, string>> = (
+  request: Request,
+  context: CloudwerkHandlerContext<TParams>
 ) => Response | Promise<Response>
 
 /**


### PR DESCRIPTION
## Summary
- Implement Cloudwerk-native route handler signature using standard Web APIs
- Add handler detection and adapter to bridge native handlers to Hono
- Deprecate legacy Hono-coupled RouteHandler type with migration path

## Changes

### Core Package (`@cloudwerk/core`)
- Add `CloudwerkHandler<TParams>` type for native handler signature
- Add `CloudwerkHandlerContext<TParams>` interface for handler context
- Deprecate `RouteHandler` and `RouteContext` with JSDoc notices
- Export new types from package index

### CLI Package (`@cloudwerk/cli`)
- Add `isCloudwerkHandler()` detection function (arity-based)
- Add `wrapCloudwerkHandler()` adapter for Hono compatibility
- Update `registerMethod()` to auto-detect and wrap handlers
- Update fixture route to demonstrate new pattern

### Tests
- Add 14 new tests for handler signature detection and behavior
- Test concurrent request isolation with params
- Test integration with `getContext()`

## API

```typescript
// New Cloudwerk-native handler
export function GET(
  request: Request, 
  { params }: CloudwerkHandlerContext<{ id: string }>
) {
  const { env } = getContext<MyEnv>()
  return json({ userId: params.id })
}

// Legacy Hono handler (still supported)
export function GET(c: Context) {
  return c.json({ data: 'ok' })
}
```

## Test Plan

- [x] Build passes
- [x] All 304 tests pass (227 core + 32 cli + 45 create-app)
- [x] Lint passes
- [x] Native handlers work with standard Request
- [x] Legacy Hono handlers continue to work
- [x] Params are correctly extracted and synchronized with `getContext()`

## Related Issues
Closes #26

## Checklist
- [x] Tests added/updated
- [x] Types properly exported
- [x] Documentation in JSDoc
- [x] No secrets committed
- [x] All quality gates passed