### PR TITLE
feat(core): implement Cloudwerk-native middleware API

### DIFF
--- a/packages/cli/__fixtures__/with-middleware/app/api/protected/middleware.ts
+++ b/packages/cli/__fixtures__/with-middleware/app/api/protected/middleware.ts
@@ -1,0 +1,25 @@
+/**
+ * Auth middleware for protected routes
+ */
+import type { Middleware } from '@cloudwerk/core'
+import { getContext } from '@cloudwerk/core'
+
+export const middleware: Middleware = async (request, next) => {
+  const ctx = getContext()
+  const authHeader = request.headers.get('Authorization')
+
+  if (!authHeader || authHeader !== 'Bearer valid-token') {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )
+  }
+
+  // Set user info for downstream handlers
+  ctx.set('user', { id: '123', name: 'Test User' })
+
+  return next()
+}

--- a/packages/cli/__fixtures__/with-middleware/app/api/protected/route.ts
+++ b/packages/cli/__fixtures__/with-middleware/app/api/protected/route.ts
@@ -1,0 +1,27 @@
+/**
+ * Protected route - requires auth middleware
+ */
+import { getContext } from '@cloudwerk/core'
+
+interface User {
+  id: string
+  name: string
+}
+
+export function GET(_request: Request, _context: { params: Record<string, string> }) {
+  const ctx = getContext()
+  const user = ctx.get<User>('user')
+  const requestStart = ctx.get<number>('requestStart')
+
+  return new Response(
+    JSON.stringify({
+      message: 'Protected endpoint',
+      user,
+      hasRequestStart: requestStart !== undefined,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}

--- a/packages/cli/__fixtures__/with-middleware/app/api/route.ts
+++ b/packages/cli/__fixtures__/with-middleware/app/api/route.ts
@@ -1,0 +1,20 @@
+/**
+ * Public API route - only root middleware applies
+ */
+import { getContext } from '@cloudwerk/core'
+
+export function GET(_request: Request, _context: { params: Record<string, string> }) {
+  const ctx = getContext()
+  const requestStart = ctx.get<number>('requestStart')
+
+  return new Response(
+    JSON.stringify({
+      message: 'Public endpoint',
+      hasRequestStart: requestStart !== undefined,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}

--- a/packages/cli/__fixtures__/with-middleware/app/middleware.ts
+++ b/packages/cli/__fixtures__/with-middleware/app/middleware.ts
@@ -1,0 +1,25 @@
+/**
+ * Root middleware - applies to all routes
+ */
+import type { Middleware } from '@cloudwerk/core'
+import { getContext } from '@cloudwerk/core'
+
+export const middleware: Middleware = async (request, next) => {
+  const ctx = getContext()
+
+  // Add timing header
+  const start = Date.now()
+  ctx.set('requestStart', start)
+
+  const response = await next()
+
+  // Add response time header
+  const duration = Date.now() - start
+  const newResponse = new Response(response.body, {
+    status: response.status,
+    headers: response.headers,
+  })
+  newResponse.headers.set('X-Response-Time', `${duration}ms`)
+
+  return newResponse
+}

--- a/packages/cli/src/__tests__/loadMiddleware.test.ts
+++ b/packages/cli/src/__tests__/loadMiddleware.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for middleware module loading.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import {
+  loadMiddlewareModule,
+  clearMiddlewareCache,
+  getMiddlewareCacheSize,
+} from '../server/loadMiddleware.js'
+
+const FIXTURES_DIR = path.join(__dirname, '../../__fixtures__')
+
+// Create a temp directory for test middleware files
+const TEMP_DIR = path.join(__dirname, '../../__fixtures__/temp-middleware')
+
+describe('loadMiddlewareModule', () => {
+  beforeEach(() => {
+    clearMiddlewareCache()
+    // Create temp directory for dynamic test files
+    if (!fs.existsSync(TEMP_DIR)) {
+      fs.mkdirSync(TEMP_DIR, { recursive: true })
+    }
+  })
+
+  afterEach(() => {
+    // Clean up temp files
+    if (fs.existsSync(TEMP_DIR)) {
+      const files = fs.readdirSync(TEMP_DIR)
+      for (const file of files) {
+        fs.unlinkSync(path.join(TEMP_DIR, file))
+      }
+      fs.rmdirSync(TEMP_DIR)
+    }
+    clearMiddlewareCache()
+  })
+
+  describe('basic loading', () => {
+    it('should load middleware with default export', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'default-export.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default async function(request: Request, next: () => Promise<Response>) {
+          return next()
+        }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeDefined()
+      expect(typeof handler).toBe('function')
+    })
+
+    it('should load middleware with named middleware export', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'named-export.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export const middleware = async (request: Request, next: () => Promise<Response>) => {
+          return next()
+        }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeDefined()
+      expect(typeof handler).toBe('function')
+    })
+
+    it('should prefer default export over named export', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'both-exports.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export const middleware = async (request: Request, next: () => Promise<Response>) => {
+          return new Response('named')
+        }
+
+        export default async function(request: Request, next: () => Promise<Response>) {
+          return new Response('default')
+        }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeDefined()
+
+      // Create a minimal Hono-like context to test the handler
+      // The adapter sets c.res with the middleware result
+      const mockContext = {
+        req: { raw: new Request('http://localhost/test') },
+        res: new Response('downstream'),
+      } as { req: { raw: Request }; res: Response }
+      const mockNext = async () => {}
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await handler!(mockContext as any, mockNext)
+      // The adapter sets c.res with the middleware's response
+      expect(await mockContext.res.text()).toBe('default')
+    })
+  })
+
+  describe('file not found', () => {
+    it('should return null for non-existent file', async () => {
+      const handler = await loadMiddlewareModule('/non/existent/path.ts')
+
+      expect(handler).toBeNull()
+    })
+
+    it('should return null for non-existent file in verbose mode', async () => {
+      const handler = await loadMiddlewareModule('/non/existent/path.ts', true)
+
+      expect(handler).toBeNull()
+    })
+  })
+
+  describe('invalid exports', () => {
+    it('should return null when no valid export exists', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'no-export.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        const helper = () => 'not exported'
+        export const notMiddleware = 'string value'
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath, true)
+
+      expect(handler).toBeNull()
+    })
+
+    it('should return null when export is not a function', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'not-function.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default { notAFunction: true }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeNull()
+    })
+  })
+
+  describe('caching', () => {
+    it('should cache compiled modules', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'cache-test.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default async function(request: Request, next: () => Promise<Response>) {
+          return next()
+        }
+        `
+      )
+
+      expect(getMiddlewareCacheSize()).toBe(0)
+
+      await loadMiddlewareModule(middlewarePath)
+      expect(getMiddlewareCacheSize()).toBe(1)
+
+      // Load again - should use cache
+      await loadMiddlewareModule(middlewarePath)
+      expect(getMiddlewareCacheSize()).toBe(1)
+    })
+
+    it('should invalidate cache when file changes', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'cache-invalidate.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default async function(request: Request, next: () => Promise<Response>) {
+          return new Response('v1')
+        }
+        `
+      )
+
+      const handler1 = await loadMiddlewareModule(middlewarePath)
+
+      // Modify file (need to wait a bit for mtime to change)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default async function(request: Request, next: () => Promise<Response>) {
+          return new Response('v2')
+        }
+        `
+      )
+
+      const handler2 = await loadMiddlewareModule(middlewarePath)
+
+      // Both should be valid handlers
+      expect(handler1).toBeDefined()
+      expect(handler2).toBeDefined()
+    })
+
+    it('should clear cache', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'clear-cache.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default async function(request: Request, next: () => Promise<Response>) {
+          return next()
+        }
+        `
+      )
+
+      await loadMiddlewareModule(middlewarePath)
+      expect(getMiddlewareCacheSize()).toBe(1)
+
+      clearMiddlewareCache()
+      expect(getMiddlewareCacheSize()).toBe(0)
+    })
+  })
+
+  describe('TypeScript compilation', () => {
+    it('should compile TypeScript middleware', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'typescript.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        import type { Middleware } from '@cloudwerk/core'
+
+        interface User {
+          id: string
+          name: string
+        }
+
+        export const middleware: Middleware = async (request: Request, next: () => Promise<Response>) => {
+          const user: User = { id: '123', name: 'Test' }
+          return next()
+        }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeDefined()
+      expect(typeof handler).toBe('function')
+    })
+
+    it('should handle import statements', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'with-imports.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        // Using external import that should be bundled
+        export default async function middleware(request: Request, next: () => Promise<Response>) {
+          const url = new URL(request.url)
+          return next()
+        }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeDefined()
+    })
+  })
+
+  describe('error handling', () => {
+    it('should return null for syntax errors in middleware', async () => {
+      const middlewarePath = path.join(TEMP_DIR, 'syntax-error.ts')
+      fs.writeFileSync(
+        middlewarePath,
+        `
+        export default async function(request { // Missing colon
+          return next()
+        }
+        `
+      )
+
+      const handler = await loadMiddlewareModule(middlewarePath)
+
+      expect(handler).toBeNull()
+    })
+  })
+})

--- a/packages/cli/src/server/loadMiddleware.ts
+++ b/packages/cli/src/server/loadMiddleware.ts
@@ -1,0 +1,216 @@
+/**
+ * @cloudwerk/cli - Middleware Loader
+ *
+ * Compiles TypeScript middleware files on-the-fly using esbuild.
+ * Similar pattern to loadHandler.ts but for middleware modules.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { builtinModules } from 'node:module'
+import { build } from 'esbuild'
+import { pathToFileURL } from 'node:url'
+import type { MiddlewareHandler } from 'hono'
+import type { Middleware, LoadedMiddlewareModule } from '@cloudwerk/core'
+import { createMiddlewareAdapter } from '@cloudwerk/core'
+
+// ============================================================================
+// Module Cache
+// ============================================================================
+
+/**
+ * Cache for compiled middleware modules to avoid recompilation.
+ * Uses mtime for cache invalidation in dev mode.
+ */
+const middlewareCache = new Map<string, { module: LoadedMiddlewareModule; mtime: number }>()
+
+// ============================================================================
+// Middleware Loading
+// ============================================================================
+
+/**
+ * Load a middleware module from the given path.
+ *
+ * Uses esbuild for TypeScript compilation and caches by mtime.
+ * Returns a Hono-compatible middleware handler wrapped with createMiddlewareAdapter.
+ *
+ * @param absolutePath - Absolute path to the middleware file
+ * @param verbose - Enable verbose logging
+ * @returns Hono middleware handler or null if not found/invalid
+ *
+ * @example
+ * const middleware = await loadMiddlewareModule('/app/middleware.ts')
+ * if (middleware) {
+ *   app.use('/api/*', middleware)
+ * }
+ */
+export async function loadMiddlewareModule(
+  absolutePath: string,
+  verbose: boolean = false
+): Promise<MiddlewareHandler | null> {
+  // Check file exists
+  if (!fs.existsSync(absolutePath)) {
+    if (verbose) {
+      console.warn(`Middleware not found: ${absolutePath}`)
+    }
+    return null
+  }
+
+  try {
+    // Check cache by mtime
+    const stat = fs.statSync(absolutePath)
+    const mtime = stat.mtimeMs
+    const cached = middlewareCache.get(absolutePath)
+
+    if (cached && cached.mtime === mtime) {
+      return extractMiddleware(cached.module, absolutePath, verbose)
+    }
+
+    // Derive esbuild target from current Node.js version
+    const nodeVersion = process.versions.node.split('.')[0]
+    const target = `node${nodeVersion}`
+
+    // Compile with esbuild
+    const result = await build({
+      entryPoints: [absolutePath],
+      bundle: true,
+      write: false,
+      format: 'esm',
+      platform: 'node',
+      target,
+      external: [
+        '@cloudwerk/core',
+        'hono',
+        // Use builtinModules for comprehensive Node.js built-in coverage
+        ...builtinModules,
+        ...builtinModules.map((m) => `node:${m}`),
+      ],
+      logLevel: verbose ? 'warning' : 'silent',
+      sourcemap: 'inline',
+    })
+
+    if (!result.outputFiles || result.outputFiles.length === 0) {
+      throw new Error('No output from esbuild')
+    }
+
+    // Write to temp file near the original file (like loadHandler.ts)
+    // This ensures proper module resolution for external packages like @cloudwerk/core
+    const cacheKey = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    const tempDir = findSafeTempDir(absolutePath)
+    const tempFile = path.join(tempDir, `.cloudwerk-middleware-${cacheKey}.mjs`)
+    fs.writeFileSync(tempFile, result.outputFiles[0].text)
+
+    try {
+      // Import module
+      const module = (await import(pathToFileURL(tempFile).href)) as LoadedMiddlewareModule
+
+      // Cache the compiled module with its mtime
+      middlewareCache.set(absolutePath, { module, mtime })
+
+      return extractMiddleware(module, absolutePath, verbose)
+    } finally {
+      // Clean up temp file
+      try {
+        fs.unlinkSync(tempFile)
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  } catch (error) {
+    // Log error with context
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Failed to compile middleware at ${absolutePath}: ${message}`)
+    return null
+  }
+}
+
+// ============================================================================
+// Middleware Extraction
+// ============================================================================
+
+/**
+ * Extract middleware function from module exports and wrap with adapter.
+ *
+ * Supports both default export and named 'middleware' export.
+ * Default export takes precedence over named export.
+ *
+ * @param module - Loaded middleware module
+ * @param absolutePath - Path to middleware file (for error messages)
+ * @param verbose - Enable verbose logging
+ * @returns Hono middleware handler or null if no valid export found
+ */
+function extractMiddleware(
+  module: LoadedMiddlewareModule,
+  absolutePath: string,
+  verbose: boolean
+): MiddlewareHandler | null {
+  // Prefer default export, fall back to named 'middleware' export
+  const middleware = module.default ?? module.middleware
+
+  if (!middleware) {
+    if (verbose) {
+      console.warn(
+        `Middleware at ${absolutePath} must export a default function or named 'middleware' export`
+      )
+    }
+    return null
+  }
+
+  // Validate export is a function
+  if (typeof middleware !== 'function') {
+    console.warn(
+      `Middleware in ${absolutePath} must export a function, got ${typeof middleware}`
+    )
+    return null
+  }
+
+  // Wrap with adapter to convert Cloudwerk signature to Hono signature
+  return createMiddlewareAdapter(middleware as Middleware)
+}
+
+// ============================================================================
+// Cache Management
+// ============================================================================
+
+/**
+ * Clear the middleware cache (useful for hot reloading in the future).
+ */
+export function clearMiddlewareCache(): void {
+  middlewareCache.clear()
+}
+
+/**
+ * Get the size of the middleware cache.
+ */
+export function getMiddlewareCacheSize(): number {
+  return middlewareCache.size
+}
+
+// ============================================================================
+// Path Utilities
+// ============================================================================
+
+/**
+ * Find a safe directory for temp files by walking up until we find
+ * a directory without special characters like brackets.
+ * This avoids URL encoding issues when using dynamic import.
+ *
+ * @param filePath - Starting file path
+ * @returns Directory path safe for temp files
+ */
+function findSafeTempDir(filePath: string): string {
+  let dir = path.dirname(filePath)
+  const hasSpecialChars = (p: string) => /\[|\]|\(|\)/.test(path.basename(p))
+
+  // Walk up until we find a directory without brackets
+  while (hasSpecialChars(dir)) {
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      // Reached root, use original directory
+      break
+    }
+    dir = parent
+  }
+
+  return dir
+}

--- a/packages/core/src/__tests__/middleware.test.ts
+++ b/packages/core/src/__tests__/middleware.test.ts
@@ -1,0 +1,618 @@
+/**
+ * @cloudwerk/core - Middleware Adapter Tests
+ *
+ * Tests for createMiddlewareAdapter() that bridges Cloudwerk middleware to Hono.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { createMiddlewareAdapter } from '../middleware.js'
+import {
+  contextMiddleware,
+  getContext,
+  runWithContext,
+  createContext,
+} from '../context.js'
+import type { Middleware, CloudwerkContext } from '../types.js'
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+/**
+ * Create a test Hono app with context middleware pre-configured.
+ * This mirrors the production setup where contextMiddleware runs first.
+ */
+function createTestApp(): Hono {
+  const app = new Hono()
+  app.use('*', contextMiddleware())
+  return app
+}
+
+/**
+ * Create a mock Hono context for lower-level testing.
+ */
+function createMockHonoContext(overrides: {
+  url?: string
+  method?: string
+  body?: string
+  headers?: Record<string, string>
+} = {}) {
+  const url = overrides.url ?? 'https://example.com/test'
+  const method = overrides.method ?? 'GET'
+
+  const request = new Request(url, {
+    method,
+    body: overrides.body,
+    headers: overrides.headers,
+  })
+
+  return {
+    req: {
+      raw: request,
+      url,
+      method,
+    },
+    env: {},
+    executionCtx: {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+    },
+    res: new Response('downstream response'),
+  } as unknown as import('hono').Context
+}
+
+// ============================================================================
+// Request Handling Tests
+// ============================================================================
+
+describe('createMiddlewareAdapter', () => {
+  describe('request handling', () => {
+    it('should pass standard Request to middleware', async () => {
+      const app = createTestApp()
+      let receivedRequest: Request | null = null
+
+      const middleware: Middleware = async (request, next) => {
+        receivedRequest = request
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      expect(receivedRequest).toBeInstanceOf(Request)
+      expect(receivedRequest!.url).toBe('http://localhost/test')
+    })
+
+    it('should provide raw request, not Hono wrapper', async () => {
+      const app = createTestApp()
+      let requestPrototype: unknown = null
+
+      const middleware: Middleware = async (request, next) => {
+        requestPrototype = Object.getPrototypeOf(request)
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      // Should be standard Request, not HonoRequest
+      expect(requestPrototype).toBe(Request.prototype)
+    })
+
+    it('should allow reading request body', async () => {
+      const app = createTestApp()
+      let body: string | null = null
+
+      const middleware: Middleware = async (request, next) => {
+        body = await request.text()
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.post('/test', () => new Response('ok'))
+
+      await app.fetch(
+        new Request('http://localhost/test', {
+          method: 'POST',
+          body: 'test body content',
+        })
+      )
+
+      expect(body).toBe('test body content')
+    })
+
+    it('should allow reading request headers', async () => {
+      const app = createTestApp()
+      let authHeader: string | null = null
+
+      const middleware: Middleware = async (request, next) => {
+        authHeader = request.headers.get('Authorization')
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      await app.fetch(
+        new Request('http://localhost/test', {
+          headers: { Authorization: 'Bearer token123' },
+        })
+      )
+
+      expect(authHeader).toBe('Bearer token123')
+    })
+  })
+
+  // ============================================================================
+  // next() Function Tests
+  // ============================================================================
+
+  describe('next() function', () => {
+    it('should return downstream response from next()', async () => {
+      const app = createTestApp()
+      let nextResponse: Response | null = null
+
+      const middleware: Middleware = async (request, next) => {
+        nextResponse = await next()
+        return nextResponse
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('downstream content', { status: 200 }))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+
+      expect(nextResponse).toBeInstanceOf(Response)
+      expect(await response.text()).toBe('downstream content')
+    })
+
+    it('should allow response modification after next()', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async (request, next) => {
+        const response = await next()
+        // Create new response with modified headers
+        const newResponse = new Response(response.body, {
+          status: response.status,
+          headers: response.headers,
+        })
+        newResponse.headers.set('X-Custom-Header', 'added-by-middleware')
+        return newResponse
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+
+      expect(response.headers.get('X-Custom-Header')).toBe('added-by-middleware')
+    })
+
+    it('should not require calling next() for early return', async () => {
+      const app = createTestApp()
+      let handlerCalled = false
+
+      const middleware: Middleware = async () => {
+        // Early return without calling next()
+        return new Response('Unauthorized', { status: 401 })
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => {
+        handlerCalled = true
+        return new Response('ok')
+      })
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+
+      expect(response.status).toBe(401)
+      expect(await response.text()).toBe('Unauthorized')
+      expect(handlerCalled).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // Context Integration Tests
+  // ============================================================================
+
+  describe('context integration', () => {
+    it('should allow getContext() within middleware', async () => {
+      const app = createTestApp()
+      let ctx: CloudwerkContext | null = null
+
+      const middleware: Middleware = async (request, next) => {
+        ctx = getContext()
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      expect(ctx).not.toBeNull()
+      expect(ctx!.requestId).toBeDefined()
+    })
+
+    it('should allow ctx.set() to store data', async () => {
+      const app = createTestApp()
+      let storedValue: unknown = null
+
+      const middleware: Middleware = async (request, next) => {
+        const ctx = getContext()
+        ctx.set('testKey', 'testValue')
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => {
+        const ctx = getContext()
+        storedValue = ctx.get('testKey')
+        return new Response('ok')
+      })
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      expect(storedValue).toBe('testValue')
+    })
+
+    it('should make middleware data available in handlers', async () => {
+      const app = createTestApp()
+      let handlerUser: unknown = null
+
+      const authMiddleware: Middleware = async (request, next) => {
+        const ctx = getContext()
+        ctx.set('user', { id: 123, name: 'Test User' })
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(authMiddleware))
+      app.get('/test', () => {
+        const ctx = getContext()
+        handlerUser = ctx.get('user')
+        return new Response('ok')
+      })
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      expect(handlerUser).toEqual({ id: 123, name: 'Test User' })
+    })
+
+    it('should isolate context between concurrent requests', async () => {
+      const app = createTestApp()
+      const results: { id: number; value: number }[] = []
+
+      const middleware: Middleware = async (request, next) => {
+        const url = new URL(request.url)
+        const id = Number(url.searchParams.get('id') || 0)
+        const ctx = getContext()
+        ctx.set('requestId', id)
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', async () => {
+        const ctx = getContext()
+        const id = ctx.get<number>('requestId') ?? 0
+
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, Math.random() * 20))
+
+        const value = ctx.get<number>('requestId') ?? 0
+        results.push({ id, value })
+
+        return new Response('ok')
+      })
+
+      // Fire concurrent requests
+      await Promise.all([
+        app.fetch(new Request('http://localhost/test?id=1')),
+        app.fetch(new Request('http://localhost/test?id=2')),
+        app.fetch(new Request('http://localhost/test?id=3')),
+        app.fetch(new Request('http://localhost/test?id=4')),
+        app.fetch(new Request('http://localhost/test?id=5')),
+      ])
+
+      // Each request should maintain its own context
+      for (const result of results) {
+        expect(result.id).toBe(result.value)
+      }
+    })
+  })
+
+  // ============================================================================
+  // Response Handling Tests
+  // ============================================================================
+
+  describe('response handling', () => {
+    it('should allow returning custom Response', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async () => {
+        return new Response(JSON.stringify({ custom: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('should not reach'))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data).toEqual({ custom: true })
+    })
+
+    it('should allow modifying response headers', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async (request, next) => {
+        const start = Date.now()
+        const response = await next()
+
+        const newResponse = new Response(response.body, {
+          status: response.status,
+          headers: response.headers,
+        })
+        newResponse.headers.set('X-Response-Time', `${Date.now() - start}ms`)
+        return newResponse
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+
+      expect(response.headers.get('X-Response-Time')).toMatch(/^\d+ms$/)
+    })
+
+    it('should preserve response body', async () => {
+      const app = createTestApp()
+      const testData = { message: 'Hello', count: 42 }
+
+      const middleware: Middleware = async (request, next) => {
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () =>
+        new Response(JSON.stringify(testData), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+      const data = await response.json()
+
+      expect(data).toEqual(testData)
+    })
+
+    it('should handle streaming responses', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async (request, next) => {
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => {
+        const encoder = new TextEncoder()
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('chunk1'))
+            controller.enqueue(encoder.encode('chunk2'))
+            controller.close()
+          },
+        })
+        return new Response(stream)
+      })
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+      const text = await response.text()
+
+      expect(text).toBe('chunk1chunk2')
+    })
+  })
+
+  // ============================================================================
+  // Error Handling Tests
+  // ============================================================================
+
+  describe('error handling', () => {
+    it('should propagate errors from middleware', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async () => {
+        throw new Error('Middleware error')
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      // Hono catches errors and returns 500
+      const response = await app.fetch(new Request('http://localhost/test'))
+      expect(response.status).toBe(500)
+    })
+
+    it('should propagate errors from next()', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async (request, next) => {
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => {
+        throw new Error('Handler error')
+      })
+
+      // Hono catches errors and returns 500
+      const response = await app.fetch(new Request('http://localhost/test'))
+      expect(response.status).toBe(500)
+    })
+
+    it('should handle async errors', async () => {
+      const app = createTestApp()
+
+      const middleware: Middleware = async () => {
+        await Promise.resolve()
+        throw new Error('Async middleware error')
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware))
+      app.get('/test', () => new Response('ok'))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+      expect(response.status).toBe(500)
+    })
+  })
+
+  // ============================================================================
+  // Middleware Chaining Tests
+  // ============================================================================
+
+  describe('middleware chaining', () => {
+    it('should execute middleware in order', async () => {
+      const app = createTestApp()
+      const executionOrder: string[] = []
+
+      const middleware1: Middleware = async (request, next) => {
+        executionOrder.push('middleware1-before')
+        const response = await next()
+        executionOrder.push('middleware1-after')
+        return response
+      }
+
+      const middleware2: Middleware = async (request, next) => {
+        executionOrder.push('middleware2-before')
+        const response = await next()
+        executionOrder.push('middleware2-after')
+        return response
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware1))
+      app.use('/test', createMiddlewareAdapter(middleware2))
+      app.get('/test', () => {
+        executionOrder.push('handler')
+        return new Response('ok')
+      })
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      expect(executionOrder).toEqual([
+        'middleware1-before',
+        'middleware2-before',
+        'handler',
+        'middleware2-after',
+        'middleware1-after',
+      ])
+    })
+
+    it('should pass data between middleware via context', async () => {
+      const app = createTestApp()
+      let handlerData: unknown = null
+
+      const middleware1: Middleware = async (request, next) => {
+        const ctx = getContext()
+        ctx.set('key1', 'value1')
+        return next()
+      }
+
+      const middleware2: Middleware = async (request, next) => {
+        const ctx = getContext()
+        const value1 = ctx.get<string>('key1')
+        ctx.set('key2', `${value1}-extended`)
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(middleware1))
+      app.use('/test', createMiddlewareAdapter(middleware2))
+      app.get('/test', () => {
+        const ctx = getContext()
+        handlerData = {
+          key1: ctx.get('key1'),
+          key2: ctx.get('key2'),
+        }
+        return new Response('ok')
+      })
+
+      await app.fetch(new Request('http://localhost/test'))
+
+      expect(handlerData).toEqual({
+        key1: 'value1',
+        key2: 'value1-extended',
+      })
+    })
+
+    it('should short-circuit on early return', async () => {
+      const app = createTestApp()
+      let middleware2Called = false
+      let handlerCalled = false
+
+      const authMiddleware: Middleware = async () => {
+        // Simulating auth failure - return early
+        return new Response('Forbidden', { status: 403 })
+      }
+
+      const loggingMiddleware: Middleware = async (request, next) => {
+        middleware2Called = true
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(authMiddleware))
+      app.use('/test', createMiddlewareAdapter(loggingMiddleware))
+      app.get('/test', () => {
+        handlerCalled = true
+        return new Response('ok')
+      })
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+
+      expect(response.status).toBe(403)
+      expect(middleware2Called).toBe(false)
+      expect(handlerCalled).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // Type Tests
+  // ============================================================================
+
+  describe('TypeScript types', () => {
+    it('should accept sync middleware', async () => {
+      const app = createTestApp()
+
+      const syncMiddleware: Middleware = (request, next) => {
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(syncMiddleware))
+      app.get('/test', () => new Response('ok'))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+      expect(response.status).toBe(200)
+    })
+
+    it('should accept async middleware', async () => {
+      const app = createTestApp()
+
+      const asyncMiddleware: Middleware = async (request, next) => {
+        await Promise.resolve()
+        return next()
+      }
+
+      app.use('/test', createMiddlewareAdapter(asyncMiddleware))
+      app.get('/test', () => new Response('ok'))
+
+      const response = await app.fetch(new Request('http://localhost/test'))
+      expect(response.status).toBe(200)
+    })
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,10 @@ export type {
   // Scanner Types
   ScannedFile,
   ScanResult,
+
+  // Middleware Types
+  Middleware,
+  LoadedMiddlewareModule,
 } from './types.js'
 
 export {
@@ -186,6 +190,15 @@ export {
   createContext,
   contextMiddleware,
 } from './context.js'
+
+// ============================================================================
+// Middleware Exports
+// ============================================================================
+
+export {
+  // Middleware Adapter
+  createMiddlewareAdapter,
+} from './middleware.js'
 
 // ============================================================================
 // Response Helper Exports

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -1,0 +1,82 @@
+/**
+ * @cloudwerk/core - Middleware Adapter
+ *
+ * Adapts Cloudwerk-native middleware to Hono middleware handlers.
+ * Cloudwerk middleware receives standard Request/Response and uses
+ * getContext() for data sharing, while Hono middleware uses Context (c).
+ */
+
+import type { MiddlewareHandler, Context } from 'hono'
+import type { Middleware } from './types.js'
+
+// ============================================================================
+// Middleware Adapter
+// ============================================================================
+
+/**
+ * Creates a Hono middleware handler from a Cloudwerk-native middleware.
+ *
+ * The adapter:
+ * 1. Passes the raw Request to the middleware
+ * 2. Wraps Hono's next() to return the downstream Response
+ * 3. Returns middleware's response directly (Hono handles response override)
+ *
+ * Context is already available via getContext() because contextMiddleware
+ * runs first in the chain (see createApp.ts line 45).
+ *
+ * @param middleware - Cloudwerk-native middleware function
+ * @returns Hono-compatible middleware handler
+ *
+ * @example
+ * ```typescript
+ * import { createMiddlewareAdapter } from '@cloudwerk/core'
+ *
+ * const authMiddleware: Middleware = async (request, next) => {
+ *   const ctx = getContext()
+ *   const token = request.headers.get('Authorization')
+ *
+ *   if (!token) {
+ *     return new Response('Unauthorized', { status: 401 })
+ *   }
+ *
+ *   ctx.set('userId', decodeToken(token).userId)
+ *   return next()
+ * }
+ *
+ * // Use with Hono
+ * app.use('/api/*', createMiddlewareAdapter(authMiddleware))
+ * ```
+ */
+export function createMiddlewareAdapter(middleware: Middleware): MiddlewareHandler {
+  return async (c: Context, next) => {
+    // Track if next() was called and capture the downstream response
+    let nextCalled = false
+    let downstreamResponse: Response | undefined
+
+    // Create wrapper for next() that returns the downstream response.
+    // Hono's next() awaits downstream handlers but doesn't return the response.
+    // We capture c.res after next() completes to get the downstream response.
+    const wrappedNext = async (): Promise<Response> => {
+      nextCalled = true
+      await next()
+      downstreamResponse = c.res
+      return c.res
+    }
+
+    // Call middleware with standard Request and wrapped next.
+    // The middleware can:
+    // 1. Call next() and return its response (passthrough)
+    // 2. Call next(), modify the response, and return modified version
+    // 3. Return early without calling next() (e.g., auth failure)
+    const response = await middleware(c.req.raw, wrappedNext)
+
+    // If middleware returned a different response than downstream,
+    // or if next() wasn't called (early return), set it on context.
+    // This ensures Hono uses the middleware's response as final.
+    if (!nextCalled || response !== downstreamResponse) {
+      c.res = response
+    }
+
+    // Return nothing - Hono uses c.res as the response
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -406,3 +406,80 @@ export interface ScanResult {
   /** All not-found files */
   notFound: ScannedFile[]
 }
+
+// ============================================================================
+// Middleware Types
+// ============================================================================
+
+/**
+ * Cloudwerk-native middleware signature.
+ *
+ * Middleware receives the raw Request object and a next() function that
+ * returns the downstream Response. Context data can be accessed and modified
+ * via getContext().
+ *
+ * @example
+ * ```typescript
+ * import type { Middleware } from '@cloudwerk/core'
+ * import { getContext, redirect } from '@cloudwerk/core'
+ *
+ * // Auth middleware that checks session and sets user data
+ * export const middleware: Middleware = async (request, next) => {
+ *   const ctx = getContext()
+ *   const session = await getSession(request)
+ *
+ *   if (!session) {
+ *     return redirect('/login')
+ *   }
+ *
+ *   ctx.set('user', session.user)
+ *   return next()
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Timing middleware that adds headers
+ * export const middleware: Middleware = async (request, next) => {
+ *   const start = Date.now()
+ *   const response = await next()
+ *
+ *   // Modify response headers
+ *   const duration = Date.now() - start
+ *   response.headers.set('X-Response-Time', `${duration}ms`)
+ *
+ *   return response
+ * }
+ * ```
+ */
+export type Middleware = (
+  request: Request,
+  next: () => Promise<Response>
+) => Response | Promise<Response>
+
+/**
+ * Module exports for middleware files.
+ * Supports both default export and named 'middleware' export.
+ *
+ * @example
+ * ```typescript
+ * // Default export
+ * export default async function (request, next) {
+ *   return next()
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Named export
+ * export const middleware = async (request, next) => {
+ *   return next()
+ * }
+ * ```
+ */
+export interface LoadedMiddlewareModule {
+  /** Default export middleware function */
+  default?: Middleware
+  /** Named 'middleware' export */
+  middleware?: Middleware
+}


### PR DESCRIPTION
## Summary

Implements Cloudwerk-native middleware signature that receives a standard `Request` object and uses `getContext()` for data sharing, with an adapter to bridge to Hono's middleware system.

**Middleware Signature:**
```typescript
type Middleware = (
  request: Request,
  next: () => Promise<Response>
) => Response | Promise<Response>
```

## Changes

### Core Package (`@cloudwerk/core`)
- Added `Middleware` and `LoadedMiddlewareModule` types with comprehensive JSDoc examples
- Implemented `createMiddlewareAdapter()` to convert Cloudwerk middleware to Hono middleware
- 23 unit tests for middleware adapter covering all use cases

### CLI Package (`@cloudwerk/cli`)
- Implemented `loadMiddlewareModule()` for TypeScript middleware compilation with esbuild
- Updated `registerRoutes.ts` to load and apply per-route middleware
- 13 unit tests for middleware loading
- 4 integration tests for middleware application

### Key Features
- Middleware receives standard `Request` object
- `next()` returns downstream `Response` for modification
- `getContext()` works within middleware
- `ctx.set()` data flows to downstream handlers
- Early returns work correctly (auth failures, etc.)
- Multiple middleware chain in correct order (root to nested)

## Test Plan

- [x] All 344 tests pass (250 core + 45 create-cloudwerk-app + 49 cli)
- [x] Build passes for all packages
- [x] Linting passes (no errors, 1 pre-existing warning)
- [x] Type checking passes

**Test coverage includes:**
- Request handling (raw Request passed to middleware)
- next() function behavior (returns downstream Response)
- Context integration (getContext, ctx.set/get)
- Response handling (custom responses, header modification)
- Error handling (middleware errors, async errors)
- Middleware chaining (execution order, data passing, short-circuit)

## Related Issues

Closes #28

## Checklist
- [x] Tests added/updated
- [x] Documentation in JSDoc
- [x] No secrets committed
- [x] All quality gates passed