### PR TITLE
feat(cli): implement page.tsx automatic rendering and layout wrapping

### DIFF
--- a/packages/cli/__fixtures__/with-pages/app/async/page.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/async/page.tsx
@@ -1,0 +1,18 @@
+/**
+ * Test fixture: Async page component (Server Component).
+ */
+
+// Simulate async data loading
+async function getData() {
+  return { message: 'Async data loaded' }
+}
+
+export default async function AsyncPage() {
+  const data = await getData()
+  return (
+    <div>
+      <h1>Async Page</h1>
+      <p>{data.message}</p>
+    </div>
+  )
+}

--- a/packages/cli/__fixtures__/with-pages/app/dashboard/layout.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+/**
+ * Test fixture: Dashboard layout component (nested).
+ */
+
+export default function DashboardLayout({ children }: { children: unknown }) {
+  return (
+    <main data-layout="dashboard">
+      <nav>Dashboard Nav</nav>
+      <section>{children}</section>
+    </main>
+  )
+}

--- a/packages/cli/__fixtures__/with-pages/app/dashboard/page.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/dashboard/page.tsx
@@ -1,0 +1,12 @@
+/**
+ * Test fixture: Dashboard page component (nested).
+ */
+
+export default function DashboardPage() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>Dashboard content</p>
+    </div>
+  )
+}

--- a/packages/cli/__fixtures__/with-pages/app/error-page/page.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/error-page/page.tsx
@@ -1,0 +1,8 @@
+/**
+ * Test fixture: Page that throws an error.
+ */
+
+export default function ErrorPage() {
+  throw new Error('Test error from page component')
+  return <div>This will never render</div>
+}

--- a/packages/cli/__fixtures__/with-pages/app/layout.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * Test fixture: Root layout component.
+ */
+
+export default function RootLayout({ children }: { children: unknown }) {
+  return (
+    <html>
+      <head>
+        <title>Test App</title>
+      </head>
+      <body data-layout="root">{children}</body>
+    </html>
+  )
+}

--- a/packages/cli/__fixtures__/with-pages/app/page.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/page.tsx
@@ -1,0 +1,12 @@
+/**
+ * Test fixture: Root page component.
+ */
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Home Page</h1>
+      <p>Welcome to the home page</p>
+    </div>
+  )
+}

--- a/packages/cli/__fixtures__/with-pages/app/protected/page.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/protected/page.tsx
@@ -1,0 +1,19 @@
+/**
+ * Test fixture: Page with route config.
+ */
+
+import type { RouteConfig } from '@cloudwerk/core'
+
+export const config: RouteConfig = {
+  auth: 'required',
+  cache: 'private',
+}
+
+export default function ProtectedPage() {
+  return (
+    <div>
+      <h1>Protected Page</h1>
+      <p>This page requires authentication</p>
+    </div>
+  )
+}

--- a/packages/cli/__fixtures__/with-pages/app/users/[id]/page.tsx
+++ b/packages/cli/__fixtures__/with-pages/app/users/[id]/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Test fixture: User detail page with dynamic params.
+ */
+
+import type { PageProps } from '@cloudwerk/core'
+
+interface UserPageParams {
+  id: string
+}
+
+export default function UserPage({
+  params,
+  searchParams,
+}: PageProps<UserPageParams>) {
+  return (
+    <div>
+      <h1>User: {params.id}</h1>
+      {searchParams.tab && <p>Tab: {searchParams.tab}</p>}
+      {searchParams.ref && (
+        <p>
+          Ref:{' '}
+          {Array.isArray(searchParams.ref)
+            ? searchParams.ref.join(', ')
+            : searchParams.ref}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/packages/cli/src/server/__tests__/parseSearchParams.test.ts
+++ b/packages/cli/src/server/__tests__/parseSearchParams.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for parseSearchParams utility.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseSearchParams } from '../parseSearchParams.js'
+
+/**
+ * Create a mock Hono Context with a given URL.
+ */
+function createMockContext(url: string) {
+  return {
+    req: {
+      url,
+    },
+  } as Parameters<typeof parseSearchParams>[0]
+}
+
+describe('parseSearchParams', () => {
+  describe('single values', () => {
+    it('should parse single value params', () => {
+      const c = createMockContext('http://localhost/page?search=hello')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({ search: 'hello' })
+    })
+
+    it('should parse multiple different params', () => {
+      const c = createMockContext('http://localhost/page?search=hello&page=1&limit=10')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({
+        search: 'hello',
+        page: '1',
+        limit: '10',
+      })
+    })
+  })
+
+  describe('multiple values for same key', () => {
+    it('should parse multiple values as array', () => {
+      const c = createMockContext('http://localhost/page?tags=a&tags=b&tags=c')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({ tags: ['a', 'b', 'c'] })
+    })
+
+    it('should handle mix of single and multiple values', () => {
+      const c = createMockContext('http://localhost/page?search=hello&tags=a&tags=b')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({
+        search: 'hello',
+        tags: ['a', 'b'],
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty query string', () => {
+      const c = createMockContext('http://localhost/page')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({})
+    })
+
+    it('should handle empty value', () => {
+      const c = createMockContext('http://localhost/page?empty=')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({ empty: '' })
+    })
+
+    it('should handle params with special characters', () => {
+      const c = createMockContext('http://localhost/page?q=hello%20world&url=https%3A%2F%2Fexample.com')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({
+        q: 'hello world',
+        url: 'https://example.com',
+      })
+    })
+
+    it('should preserve order of unique keys', () => {
+      const c = createMockContext('http://localhost/page?a=1&b=2&c=3')
+      const result = parseSearchParams(c)
+      const keys = Object.keys(result)
+
+      expect(keys).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  describe('boolean-like and numeric values', () => {
+    it('should keep values as strings', () => {
+      const c = createMockContext('http://localhost/page?active=true&count=42&enabled=false')
+      const result = parseSearchParams(c)
+
+      expect(result).toEqual({
+        active: 'true',
+        count: '42',
+        enabled: 'false',
+      })
+      expect(typeof result.count).toBe('string')
+    })
+  })
+})

--- a/packages/cli/src/server/__tests__/registerRoutes.page.test.ts
+++ b/packages/cli/src/server/__tests__/registerRoutes.page.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for page registration in registerRoutes.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import * as path from 'node:path'
+import { Hono } from 'hono'
+import {
+  scanRoutes,
+  buildRouteManifest,
+  resolveLayouts,
+  resolveMiddleware,
+} from '@cloudwerk/core'
+import { registerRoutes } from '../registerRoutes.js'
+import { clearPageModuleCache } from '../loadPage.js'
+import { clearLayoutModuleCache } from '../loadLayout.js'
+
+const FIXTURES_DIR = path.join(__dirname, '../../../__fixtures__')
+
+// Create mock logger
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    log: vi.fn(),
+  }
+}
+
+/**
+ * Helper to create a route manifest from a fixture directory.
+ */
+async function createManifest(routesDir: string) {
+  const scanResult = await scanRoutes(routesDir, { extensions: ['.ts', '.tsx'] })
+  return buildRouteManifest(scanResult, routesDir, resolveLayouts, resolveMiddleware)
+}
+
+describe('registerRoutes - page support', () => {
+  beforeEach(() => {
+    clearPageModuleCache()
+    clearLayoutModuleCache()
+  })
+
+  describe('basic page registration', () => {
+    it('should register page.tsx as GET route', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      const routes = await registerRoutes(app, manifest, logger)
+
+      // Find the root page route
+      const homeRoute = routes.find((r) => r.pattern === '/' && r.method === 'GET')
+      expect(homeRoute).toBeDefined()
+      expect(homeRoute?.filePath).toContain('page.tsx')
+    })
+
+    it('should return HTML response with correct content-type', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/')
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toContain('text/html')
+
+      const html = await response.text()
+      expect(html).toContain('Home Page')
+    })
+  })
+
+  describe('layout nesting', () => {
+    it('should apply layouts in correct order (root wraps all)', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/dashboard')
+      const html = await response.text()
+
+      // Root layout should be outermost (html/body with data-layout="root")
+      expect(html).toContain('data-layout="root"')
+      expect(html).toContain('data-layout="dashboard"')
+
+      // Verify nesting order: root contains dashboard
+      // The root layout with data-layout="root" should come before data-layout="dashboard"
+      const rootLayoutIndex = html.indexOf('data-layout="root"')
+      const dashboardLayoutIndex = html.indexOf('data-layout="dashboard"')
+      expect(rootLayoutIndex).toBeLessThan(dashboardLayoutIndex)
+
+      // Page content should be innermost
+      expect(html).toContain('Dashboard')
+    })
+
+    it('should render page without layouts when none exist', async () => {
+      // The async page doesn't have its own layout, but root layout applies
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/async')
+      const html = await response.text()
+
+      // Should have root layout wrapping
+      expect(html).toContain('data-layout="root"')
+      // But no dashboard layout
+      expect(html).not.toContain('data-layout="dashboard"')
+      // Should have async page content
+      expect(html).toContain('Async Page')
+    })
+  })
+
+  describe('dynamic parameters', () => {
+    it('should pass params from dynamic segments to page', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/users/123')
+      const html = await response.text()
+
+      expect(html).toContain('User: 123')
+    })
+  })
+
+  describe('searchParams', () => {
+    it('should parse single searchParams correctly', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/users/456?tab=settings')
+      const html = await response.text()
+
+      expect(html).toContain('User: 456')
+      expect(html).toContain('Tab: settings')
+    })
+
+    it('should parse multiple searchParams with same key as array', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/users/789?ref=a&ref=b')
+      const html = await response.text()
+
+      expect(html).toContain('User: 789')
+      expect(html).toContain('Ref: a, b')
+    })
+  })
+
+  describe('async components', () => {
+    it('should await async page component (Server Component)', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/async')
+      const html = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(html).toContain('Async Page')
+      expect(html).toContain('Async data loaded')
+    })
+  })
+
+  describe('route config', () => {
+    it('should apply route config from page exports', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger, true) // verbose mode
+
+      // Verify config was applied (logged in verbose mode)
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Applied page config')
+      )
+    })
+  })
+
+  describe('error handling', () => {
+    it('should return 500 when page component throws', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      const response = await app.request('http://localhost/error-page')
+      expect(response.status).toBe(500)
+
+      const html = await response.text()
+      expect(html).toContain('Internal Server Error')
+    })
+
+    it('should log error details for debugging', async () => {
+      const app = new Hono()
+      const logger = createMockLogger()
+      const routesDir = path.join(FIXTURES_DIR, 'with-pages/app')
+      const manifest = await createManifest(routesDir)
+
+      await registerRoutes(app, manifest, logger)
+
+      await app.request('http://localhost/error-page')
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error rendering page')
+      )
+    })
+  })
+})

--- a/packages/cli/src/server/loadLayout.ts
+++ b/packages/cli/src/server/loadLayout.ts
@@ -1,0 +1,197 @@
+/**
+ * @cloudwerk/cli - Layout Component Loader
+ *
+ * Compiles TypeScript layout components on-the-fly using esbuild.
+ * Similar pattern to loadPage.ts.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { builtinModules } from 'node:module'
+import { build } from 'esbuild'
+import { pathToFileURL } from 'node:url'
+import type { LayoutComponent } from '@cloudwerk/core'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A loaded layout module with default component export.
+ */
+export interface LoadedLayoutModule {
+  /** Default export: the layout component function */
+  default: LayoutComponent
+}
+
+// ============================================================================
+// Module Cache
+// ============================================================================
+
+/**
+ * Cache for compiled layout modules to avoid recompilation.
+ * Uses mtime for cache invalidation in dev mode.
+ */
+const layoutModuleCache = new Map<string, { module: LoadedLayoutModule; mtime: number }>()
+
+// ============================================================================
+// Layout Loading
+// ============================================================================
+
+/**
+ * Load a layout component module by compiling TypeScript/TSX on-the-fly.
+ *
+ * Uses esbuild to compile the file to ESM with automatic JSX transform
+ * configured for Hono JSX. Results are cached based on file mtime.
+ *
+ * @param absolutePath - Absolute path to the layout file
+ * @param verbose - Enable verbose logging (passed to esbuild)
+ * @returns Loaded module with default layout component export
+ *
+ * @example
+ * const module = await loadLayoutModule('/app/layout.tsx')
+ * const LayoutComponent = module.default
+ * const element = LayoutComponent({ children: <Page />, params: {} })
+ */
+export async function loadLayoutModule(
+  absolutePath: string,
+  verbose: boolean = false
+): Promise<LoadedLayoutModule> {
+  try {
+    // Check file modification time for cache invalidation
+    const stat = fs.statSync(absolutePath)
+    const mtime = stat.mtimeMs
+
+    // Return cached module if file hasn't changed
+    const cached = layoutModuleCache.get(absolutePath)
+    if (cached && cached.mtime === mtime) {
+      return cached.module
+    }
+
+    // Derive esbuild target from current Node.js version
+    const nodeVersion = process.versions.node.split('.')[0]
+    const target = `node${nodeVersion}`
+
+    // Build the TypeScript/TSX file with JSX support
+    const result = await build({
+      entryPoints: [absolutePath],
+      bundle: true,
+      write: false,
+      format: 'esm',
+      platform: 'node',
+      target,
+      jsx: 'automatic',
+      jsxImportSource: 'hono/jsx',
+      external: [
+        '@cloudwerk/core',
+        '@cloudwerk/ui',
+        'hono',
+        'hono/jsx',
+        'hono/jsx/dom',
+        'hono/jsx/streaming',
+        'hono/html',
+        // Use builtinModules for comprehensive Node.js built-in coverage
+        ...builtinModules,
+        ...builtinModules.map((m) => `node:${m}`),
+      ],
+      logLevel: verbose ? 'warning' : 'silent',
+      sourcemap: 'inline',
+    })
+
+    if (!result.outputFiles || result.outputFiles.length === 0) {
+      throw new Error('No output from esbuild')
+    }
+
+    const code = result.outputFiles[0].text
+
+    // Write to temp file in a safe location within the project tree
+    // This ensures proper module resolution for external packages
+    const cacheKey = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    const tempDir = findSafeTempDir(absolutePath)
+    const tempFile = path.join(tempDir, `.cloudwerk-layout-${cacheKey}.mjs`)
+    fs.writeFileSync(tempFile, code)
+
+    try {
+      const rawModule = (await import(pathToFileURL(tempFile).href)) as LoadedLayoutModule
+
+      // Validate that default export exists and is a function
+      if (!rawModule.default) {
+        throw new Error('Layout must have a default export')
+      }
+
+      if (typeof rawModule.default !== 'function') {
+        throw new Error(
+          `Layout default export must be a function (component), got ${typeof rawModule.default}`
+        )
+      }
+
+      // Create module
+      const module: LoadedLayoutModule = {
+        default: rawModule.default,
+      }
+
+      // Cache the compiled module with its mtime
+      layoutModuleCache.set(absolutePath, { module, mtime })
+
+      return module
+    } finally {
+      // Clean up temp file
+      try {
+        fs.unlinkSync(tempFile)
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  } catch (error) {
+    // Re-throw with more context
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to compile layout at ${absolutePath}: ${message}`)
+  }
+}
+
+// ============================================================================
+// Cache Management
+// ============================================================================
+
+/**
+ * Clear the layout module cache (useful for hot reloading in the future).
+ */
+export function clearLayoutModuleCache(): void {
+  layoutModuleCache.clear()
+}
+
+/**
+ * Get the size of the layout module cache.
+ */
+export function getLayoutModuleCacheSize(): number {
+  return layoutModuleCache.size
+}
+
+// ============================================================================
+// Path Utilities
+// ============================================================================
+
+/**
+ * Find a safe directory for temp files by walking up until we find
+ * a directory without special characters like brackets.
+ * This avoids URL encoding issues when using dynamic import.
+ *
+ * @param filePath - Starting file path
+ * @returns Directory path safe for temp files
+ */
+function findSafeTempDir(filePath: string): string {
+  let dir = path.dirname(filePath)
+  const hasSpecialChars = (p: string) => /\[|\]|\(|\)/.test(path.basename(p))
+
+  // Walk up until we find a directory without brackets
+  while (hasSpecialChars(dir)) {
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      // Reached root, use original directory
+      break
+    }
+    dir = parent
+  }
+
+  return dir
+}

--- a/packages/cli/src/server/loadPage.ts
+++ b/packages/cli/src/server/loadPage.ts
@@ -1,0 +1,209 @@
+/**
+ * @cloudwerk/cli - Page Component Loader
+ *
+ * Compiles TypeScript page components on-the-fly using esbuild.
+ * Similar pattern to loadHandler.ts but configured for JSX.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { builtinModules } from 'node:module'
+import { build } from 'esbuild'
+import { pathToFileURL } from 'node:url'
+import { validateRouteConfig } from '@cloudwerk/core'
+import type { PageComponent, RouteConfig } from '@cloudwerk/core'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A loaded page module with default component export and optional config.
+ */
+export interface LoadedPageModule {
+  /** Default export: the page component function */
+  default: PageComponent
+  /** Optional route configuration */
+  config?: RouteConfig
+}
+
+// ============================================================================
+// Module Cache
+// ============================================================================
+
+/**
+ * Cache for compiled page modules to avoid recompilation.
+ * Uses mtime for cache invalidation in dev mode.
+ */
+const pageModuleCache = new Map<string, { module: LoadedPageModule; mtime: number }>()
+
+// ============================================================================
+// Page Loading
+// ============================================================================
+
+/**
+ * Load a page component module by compiling TypeScript/TSX on-the-fly.
+ *
+ * Uses esbuild to compile the file to ESM with automatic JSX transform
+ * configured for Hono JSX. Results are cached based on file mtime.
+ *
+ * @param absolutePath - Absolute path to the page file
+ * @param verbose - Enable verbose logging (passed to esbuild)
+ * @returns Loaded module with default page component export
+ *
+ * @example
+ * const module = await loadPageModule('/app/page.tsx')
+ * const PageComponent = module.default
+ * const element = PageComponent({ params: {}, searchParams: {} })
+ */
+export async function loadPageModule(
+  absolutePath: string,
+  verbose: boolean = false
+): Promise<LoadedPageModule> {
+  try {
+    // Check file modification time for cache invalidation
+    const stat = fs.statSync(absolutePath)
+    const mtime = stat.mtimeMs
+
+    // Return cached module if file hasn't changed
+    const cached = pageModuleCache.get(absolutePath)
+    if (cached && cached.mtime === mtime) {
+      return cached.module
+    }
+
+    // Derive esbuild target from current Node.js version
+    const nodeVersion = process.versions.node.split('.')[0]
+    const target = `node${nodeVersion}`
+
+    // Build the TypeScript/TSX file with JSX support
+    const result = await build({
+      entryPoints: [absolutePath],
+      bundle: true,
+      write: false,
+      format: 'esm',
+      platform: 'node',
+      target,
+      jsx: 'automatic',
+      jsxImportSource: 'hono/jsx',
+      external: [
+        '@cloudwerk/core',
+        '@cloudwerk/ui',
+        'hono',
+        'hono/jsx',
+        'hono/jsx/dom',
+        'hono/jsx/streaming',
+        'hono/html',
+        // Use builtinModules for comprehensive Node.js built-in coverage
+        ...builtinModules,
+        ...builtinModules.map((m) => `node:${m}`),
+      ],
+      logLevel: verbose ? 'warning' : 'silent',
+      sourcemap: 'inline',
+    })
+
+    if (!result.outputFiles || result.outputFiles.length === 0) {
+      throw new Error('No output from esbuild')
+    }
+
+    const code = result.outputFiles[0].text
+
+    // Write to temp file in a safe location within the project tree
+    // This ensures proper module resolution for external packages
+    const cacheKey = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    const tempDir = findSafeTempDir(absolutePath)
+    const tempFile = path.join(tempDir, `.cloudwerk-page-${cacheKey}.mjs`)
+    fs.writeFileSync(tempFile, code)
+
+    try {
+      const rawModule = (await import(pathToFileURL(tempFile).href)) as LoadedPageModule & {
+        config?: unknown
+      }
+
+      // Validate that default export exists and is a function
+      if (!rawModule.default) {
+        throw new Error('Page must have a default export')
+      }
+
+      if (typeof rawModule.default !== 'function') {
+        throw new Error(
+          `Page default export must be a function (component), got ${typeof rawModule.default}`
+        )
+      }
+
+      // Validate config if present
+      let validatedConfig: RouteConfig | undefined = undefined
+      if ('config' in rawModule && rawModule.config !== undefined) {
+        validatedConfig = validateRouteConfig(rawModule.config, absolutePath)
+      }
+
+      // Create module with validated config
+      const module: LoadedPageModule = {
+        default: rawModule.default,
+        config: validatedConfig,
+      }
+
+      // Cache the compiled module with its mtime
+      pageModuleCache.set(absolutePath, { module, mtime })
+
+      return module
+    } finally {
+      // Clean up temp file
+      try {
+        fs.unlinkSync(tempFile)
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  } catch (error) {
+    // Re-throw with more context
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to compile page at ${absolutePath}: ${message}`)
+  }
+}
+
+// ============================================================================
+// Cache Management
+// ============================================================================
+
+/**
+ * Clear the page module cache (useful for hot reloading in the future).
+ */
+export function clearPageModuleCache(): void {
+  pageModuleCache.clear()
+}
+
+/**
+ * Get the size of the page module cache.
+ */
+export function getPageModuleCacheSize(): number {
+  return pageModuleCache.size
+}
+
+// ============================================================================
+// Path Utilities
+// ============================================================================
+
+/**
+ * Find a safe directory for temp files by walking up until we find
+ * a directory without special characters like brackets.
+ * This avoids URL encoding issues when using dynamic import.
+ *
+ * @param filePath - Starting file path
+ * @returns Directory path safe for temp files
+ */
+function findSafeTempDir(filePath: string): string {
+  let dir = path.dirname(filePath)
+  const hasSpecialChars = (p: string) => /\[|\]|\(|\)/.test(path.basename(p))
+
+  // Walk up until we find a directory without brackets
+  while (hasSpecialChars(dir)) {
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      // Reached root, use original directory
+      break
+    }
+    dir = parent
+  }
+
+  return dir
+}

--- a/packages/cli/src/server/parseSearchParams.ts
+++ b/packages/cli/src/server/parseSearchParams.ts
@@ -1,0 +1,49 @@
+/**
+ * @cloudwerk/cli - Search Params Parser
+ *
+ * Utility for parsing URL search parameters from Hono Context.
+ */
+
+import type { Context } from 'hono'
+
+/**
+ * Parse search params from request URL.
+ *
+ * Handles multiple values for the same key by converting to array.
+ * Single values remain as strings, multiple values become string arrays.
+ *
+ * @param c - Hono context
+ * @returns Parsed search params object
+ *
+ * @example
+ * // /page?tags=a&tags=b&page=1
+ * // Returns: { tags: ['a', 'b'], page: '1' }
+ *
+ * @example
+ * // /page?search=hello
+ * // Returns: { search: 'hello' }
+ *
+ * @example
+ * // /page
+ * // Returns: {}
+ */
+export function parseSearchParams(
+  c: Context
+): Record<string, string | string[] | undefined> {
+  const result: Record<string, string | string[] | undefined> = {}
+  const url = new URL(c.req.url)
+
+  for (const [key, value] of url.searchParams.entries()) {
+    const existing = result[key]
+    if (existing !== undefined) {
+      // Convert to array if not already, then append
+      result[key] = Array.isArray(existing)
+        ? [...existing, value]
+        : [existing, value]
+    } else {
+      result[key] = value
+    }
+  }
+
+  return result
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -4,7 +4,13 @@
  * CLI-specific types for the development server and commands.
  */
 
-import type { CloudwerkConfig, HttpMethod, RouteConfig } from '@cloudwerk/core'
+import type {
+  CloudwerkConfig,
+  HttpMethod,
+  RouteConfig,
+  PageComponent,
+  LayoutComponent,
+} from '@cloudwerk/core'
 
 // ============================================================================
 // CLI Option Types
@@ -120,6 +126,28 @@ export interface Logger {
   error(message: string): void
   debug(message: string): void
   log(message: string): void
+}
+
+// ============================================================================
+// Page & Layout Module Types
+// ============================================================================
+
+/**
+ * A loaded page module with default component export and optional config.
+ */
+export interface LoadedPageModule {
+  /** Default export: the page component function */
+  default: PageComponent
+  /** Optional route configuration */
+  config?: RouteConfig
+}
+
+/**
+ * A loaded layout module with default component export.
+ */
+export interface LoadedLayoutModule {
+  /** Default export: the layout component function */
+  default: LayoutComponent
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements automatic handling of `page.tsx` files where the framework wraps the default export component in a `render()` call and applies layouts from the directory hierarchy.

This enables developers to:
- Write components instead of route handlers for UI routes
- Have layouts automatically applied in correct nesting order
- Use the same middleware and route config patterns as route.ts files

## Changes

### New Files
- `packages/cli/src/server/loadPage.ts` - Page component loader using esbuild with JSX automatic mode
- `packages/cli/src/server/loadLayout.ts` - Layout component loader using esbuild with JSX
- `packages/cli/src/server/parseSearchParams.ts` - URL query string parser utility
- Test fixtures in `packages/cli/__fixtures__/with-pages/`
- Integration tests for page registration and searchParams parsing

### Modified Files
- `packages/cli/src/server/registerRoutes.ts` - Added page file handling branch
- `packages/cli/src/types.ts` - Added `LoadedPageModule` and `LoadedLayoutModule` types

## Key Implementation Details

### Layout Wrapping Order
Given layouts `[root, dashboard, settings]` (root-to-leaf from resolver):
1. Reverse to get `[settings, dashboard, root]`
2. Wrap page with settings: `<Settings><Page/></Settings>`
3. Wrap with dashboard: `<Dashboard><Settings><Page/></Settings></Dashboard>`
4. Wrap with root: `<Root><Dashboard><Settings><Page/></Settings></Dashboard></Root>`

Result: Proper nesting where root wraps all, leaf closest to page.

### Features
- Page components are registered as GET routes automatically
- Layouts applied in correct order (root → leaf)
- SearchParams parsing with multiple value support (same key as array)
- Middleware and route config support for pages
- Async page/layout components supported (Server Components)
- Error handling returns 500 with logged details

## Test Plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (78 tests, including 20 new tests)
- [x] `pnpm lint` passes
- [ ] Manual testing: Create a page.tsx and verify it renders with layouts

## Related Issues

Closes #32

Part of v0.2.0 - Page Components & Data Loading milestone.

## Checklist

- [x] Tests added/updated (20 new tests)
- [x] Documentation in code (JSDoc comments)
- [x] No secrets committed
- [x] All quality gates passed