### PR TITLE
feat(cli): wire hydration infrastructure for client components

### DIFF
--- a/.changeset/client-hydration.md
+++ b/.changeset/client-hydration.md
@@ -1,0 +1,17 @@
+---
+"@cloudwerk/cli": minor
+---
+
+feat(cli): wire hydration infrastructure into rendering pipeline
+
+Client components marked with `'use client'` directive are now hydrated on the client side:
+
+- Register `/__cloudwerk/*` routes to serve client bundles and hydration runtime
+- Track client components during page and layout loading
+- Inject hydration scripts into HTML responses for pages with client components
+- Support both Hono JSX and React renderers
+- Add request-scoped manifest generation for efficient per-request hydration
+
+The Counter component in `template-hono-jsx` is now interactive - clicking increments the count.
+
+Closes #133

--- a/packages/cli/src/server/__tests__/hydrationRoutes.test.ts
+++ b/packages/cli/src/server/__tests__/hydrationRoutes.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for hydration routes.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Hono } from 'hono'
+import { registerHydrationRoutes, clearRuntimeCache } from '../hydrationRoutes.js'
+import { createManifestTracker, trackIfClientComponent } from '../hydrationManifest.js'
+import type { Logger } from '../../types.js'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+// Mock logger
+const mockLogger: Logger = {
+  info: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  log: vi.fn(),
+}
+
+// Test fixtures directory
+const fixturesDir = path.resolve(__dirname, '../../__fixtures__')
+const tempDir = path.join(fixturesDir, 'temp-hydration')
+
+describe('hydrationRoutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearRuntimeCache()
+
+    // Ensure temp directory exists
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true })
+    }
+  })
+
+  describe('registerHydrationRoutes', () => {
+    it('should register routes at /__cloudwerk/*', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      // Check that we can get the runtime
+      const res = await app.request('/__cloudwerk/runtime.js')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Content-Type')).toContain('application/javascript')
+    })
+
+    it('should serve Hono JSX runtime at /__cloudwerk/runtime.js', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      const res = await app.request('/__cloudwerk/runtime.js')
+      expect(res.status).toBe(200)
+
+      const content = await res.text()
+      expect(content).toContain('hono/jsx/dom')
+      expect(content).toContain('render')
+      expect(content).toContain('useState')
+    })
+
+    it('should serve React runtime at /__cloudwerk/react-runtime.js', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+        renderer: 'react',
+      })
+
+      const res = await app.request('/__cloudwerk/react-runtime.js')
+      expect(res.status).toBe(200)
+
+      const content = await res.text()
+      expect(content).toContain('react')
+      expect(content).toContain('hydrateRoot')
+    })
+
+    it('should return 404 for unknown component', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      const res = await app.request('/__cloudwerk/unknown_component.js')
+      expect(res.status).toBe(404)
+
+      const content = await res.text()
+      expect(content).toContain('Component not found')
+    })
+
+    it('should serve component bundle when tracked', async () => {
+      // Create a temporary client component file
+      const componentPath = path.join(tempDir, 'TestCounter.tsx')
+      fs.writeFileSync(
+        componentPath,
+        `'use client'
+
+import { useState } from 'hono/jsx'
+
+export default function TestCounter() {
+  const [count, setCount] = useState(0)
+  return <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+        const tracker = createManifestTracker(tempDir)
+
+        // Track the component
+        trackIfClientComponent(tracker, componentPath)
+
+        registerHydrationRoutes(app, {
+          tracker,
+          appDir: tempDir,
+          logger: mockLogger,
+        })
+
+        // Get the component bundle
+        const res = await app.request('/__cloudwerk/TestCounter.js')
+        expect(res.status).toBe(200)
+        expect(res.headers.get('Content-Type')).toContain('application/javascript')
+
+        const content = await res.text()
+        expect(content).toContain('useState')
+      } finally {
+        // Cleanup
+        if (fs.existsSync(componentPath)) {
+          fs.unlinkSync(componentPath)
+        }
+      }
+    })
+
+    it('should cache runtime bundles', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      // Request twice
+      const res1 = await app.request('/__cloudwerk/runtime.js')
+      const res2 = await app.request('/__cloudwerk/runtime.js')
+
+      const content1 = await res1.text()
+      const content2 = await res2.text()
+
+      // Content should be identical (cached)
+      expect(content1).toBe(content2)
+    })
+
+    it('should log registration in verbose mode', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+        verbose: true,
+      })
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Registered hydration routes at /__cloudwerk/*'
+      )
+    })
+
+    it('should set correct cache headers for runtime', async () => {
+      const app = new Hono()
+      const tracker = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app, {
+        tracker,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      const res = await app.request('/__cloudwerk/runtime.js')
+
+      // Runtime should have long cache (immutable)
+      expect(res.headers.get('Cache-Control')).toContain('max-age=31536000')
+      expect(res.headers.get('Cache-Control')).toContain('immutable')
+    })
+
+    it('should set no-cache headers for component bundles in dev', async () => {
+      // Create a temporary client component file
+      const componentPath = path.join(tempDir, 'DevCounter.tsx')
+      fs.writeFileSync(
+        componentPath,
+        `'use client'
+
+import { useState } from 'hono/jsx'
+
+export default function DevCounter() {
+  const [count, setCount] = useState(0)
+  return <button>Count: {count}</button>
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+        const tracker = createManifestTracker(tempDir)
+        trackIfClientComponent(tracker, componentPath)
+
+        registerHydrationRoutes(app, {
+          tracker,
+          appDir: tempDir,
+          logger: mockLogger,
+        })
+
+        const res = await app.request('/__cloudwerk/DevCounter.js')
+
+        // Component bundles should not be cached in dev
+        expect(res.headers.get('Cache-Control')).toBe('no-cache')
+      } finally {
+        if (fs.existsSync(componentPath)) {
+          fs.unlinkSync(componentPath)
+        }
+      }
+    })
+  })
+
+  describe('clearRuntimeCache', () => {
+    it('should clear cached runtimes', async () => {
+      const app1 = new Hono()
+      const tracker1 = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app1, {
+        tracker: tracker1,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      // Cache the runtime
+      await app1.request('/__cloudwerk/runtime.js')
+
+      // Clear cache
+      clearRuntimeCache()
+
+      // Create new app and request again
+      const app2 = new Hono()
+      const tracker2 = createManifestTracker(tempDir)
+
+      registerHydrationRoutes(app2, {
+        tracker: tracker2,
+        appDir: tempDir,
+        logger: mockLogger,
+      })
+
+      const res = await app2.request('/__cloudwerk/runtime.js')
+      expect(res.status).toBe(200)
+    })
+  })
+})

--- a/packages/cli/src/server/__tests__/registerRoutes.hydration.test.ts
+++ b/packages/cli/src/server/__tests__/registerRoutes.hydration.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for client component hydration in route registration.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Hono } from 'hono'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import type { RouteManifest, ScanResult, RouteEntry } from '@cloudwerk/core'
+import { registerRoutes } from '../registerRoutes.js'
+import { createManifestTracker } from '../hydrationManifest.js'
+import type { Logger } from '../../types.js'
+
+// Mock logger
+const mockLogger: Logger = {
+  info: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  log: vi.fn(),
+}
+
+// Test fixtures directory
+const fixturesDir = path.resolve(__dirname, '../../__fixtures__')
+const tempDir = path.join(fixturesDir, 'temp-hydration-routes')
+
+// Helper to create minimal scan result
+function createScanResult(): ScanResult {
+  return {
+    routes: [],
+    layouts: [],
+    middleware: [],
+    loading: [],
+    errors: [],
+    notFound: [],
+  }
+}
+
+// Helper to create a route entry
+function createRouteEntry(
+  urlPattern: string,
+  filePath: string,
+  absolutePath: string
+): RouteEntry {
+  return {
+    urlPattern,
+    filePath,
+    absolutePath,
+    fileType: 'page',
+    segments: [],
+    layouts: [],
+    middleware: [],
+    priority: 1,
+  }
+}
+
+// Helper to create route manifest
+function createManifest(
+  routes: RouteEntry[],
+  rootDir: string
+): RouteManifest {
+  return {
+    routes,
+    layouts: new Map(),
+    middleware: new Map(),
+    errors: [],
+    warnings: [],
+    generatedAt: new Date(),
+    rootDir,
+  }
+}
+
+describe('registerRoutes - hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Ensure temp directory exists
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true })
+    }
+  })
+
+  describe('client component tracking', () => {
+    it('should track client components during page loading', async () => {
+      // Create a temporary client component page
+      const pagePath = path.join(tempDir, 'ClientPage.tsx')
+      fs.writeFileSync(
+        pagePath,
+        `'use client'
+
+import { useState } from 'hono/jsx'
+
+export default function ClientPage() {
+  const [count, setCount] = useState(0)
+  return <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+        const tracker = createManifestTracker(tempDir)
+
+        const manifest = createManifest(
+          [createRouteEntry('/', 'ClientPage.tsx', pagePath)],
+          tempDir
+        )
+
+        await registerRoutes(
+          app,
+          manifest,
+          createScanResult(),
+          mockLogger,
+          false,
+          tracker
+        )
+
+        // The tracker should have the component
+        expect(tracker.components.size).toBe(1)
+        expect(tracker.components.has(pagePath)).toBe(true)
+      } finally {
+        if (fs.existsSync(pagePath)) {
+          fs.unlinkSync(pagePath)
+        }
+      }
+    })
+
+    it('should inject hydration scripts for pages with client components', async () => {
+      // Create a temporary client component page
+      const pagePath = path.join(tempDir, 'HydratedPage.tsx')
+      fs.writeFileSync(
+        pagePath,
+        `'use client'
+
+import { useState } from 'hono/jsx'
+
+export default function HydratedPage() {
+  const [count, setCount] = useState(0)
+  return (
+    <html>
+      <head><title>Test</title></head>
+      <body>
+        <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
+      </body>
+    </html>
+  )
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+        const tracker = createManifestTracker(tempDir)
+
+        const manifest = createManifest(
+          [createRouteEntry('/hydrated', 'HydratedPage.tsx', pagePath)],
+          tempDir
+        )
+
+        await registerRoutes(
+          app,
+          manifest,
+          createScanResult(),
+          mockLogger,
+          false,
+          tracker
+        )
+
+        // Request the page
+        const res = await app.request('/hydrated')
+        expect(res.status).toBe(200)
+
+        const html = await res.text()
+
+        // Should have preload hints
+        expect(html).toContain('<link rel="modulepreload"')
+        expect(html).toContain('/__cloudwerk/')
+
+        // Should have hydration script
+        expect(html).toContain('data-hydrate-id')
+        expect(html).toContain('/__cloudwerk/runtime.js')
+      } finally {
+        if (fs.existsSync(pagePath)) {
+          fs.unlinkSync(pagePath)
+        }
+      }
+    })
+
+    it('should not inject hydration for server-only pages', async () => {
+      // Create a regular server component page
+      const pagePath = path.join(tempDir, 'ServerPage.tsx')
+      fs.writeFileSync(
+        pagePath,
+        `// No 'use client' directive - this is a server component
+
+export default function ServerPage() {
+  return (
+    <html>
+      <head><title>Server Page</title></head>
+      <body>
+        <h1>Hello from server</h1>
+      </body>
+    </html>
+  )
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+        const tracker = createManifestTracker(tempDir)
+
+        const manifest = createManifest(
+          [createRouteEntry('/server', 'ServerPage.tsx', pagePath)],
+          tempDir
+        )
+
+        await registerRoutes(
+          app,
+          manifest,
+          createScanResult(),
+          mockLogger,
+          false,
+          tracker
+        )
+
+        // Request the page
+        const res = await app.request('/server')
+        expect(res.status).toBe(200)
+
+        const html = await res.text()
+
+        // Should NOT have hydration scripts since no client components
+        expect(html).not.toContain('data-hydrate-id')
+        expect(html).not.toContain('/__cloudwerk/runtime.js')
+      } finally {
+        if (fs.existsSync(pagePath)) {
+          fs.unlinkSync(pagePath)
+        }
+      }
+    })
+
+    it('should work without hydration tracker (backward compatibility)', async () => {
+      // Create a regular server component page
+      const pagePath = path.join(tempDir, 'NoTrackerPage.tsx')
+      fs.writeFileSync(
+        pagePath,
+        `export default function NoTrackerPage() {
+  return <h1>Hello</h1>
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+
+        const manifest = createManifest(
+          [createRouteEntry('/no-tracker', 'NoTrackerPage.tsx', pagePath)],
+          tempDir
+        )
+
+        // Register without tracker (undefined)
+        await registerRoutes(
+          app,
+          manifest,
+          createScanResult(),
+          mockLogger,
+          false,
+          undefined
+        )
+
+        // Request the page
+        const res = await app.request('/no-tracker')
+        expect(res.status).toBe(200)
+
+        const html = await res.text()
+        expect(html).toContain('Hello')
+      } finally {
+        if (fs.existsSync(pagePath)) {
+          fs.unlinkSync(pagePath)
+        }
+      }
+    })
+  })
+
+  describe('hydration manifest generation', () => {
+    it('should include all used client components in manifest', async () => {
+      // Create multiple client components
+      const counterPath = path.join(tempDir, 'Counter.tsx')
+      fs.writeFileSync(
+        counterPath,
+        `'use client'
+import { useState } from 'hono/jsx'
+export default function Counter() {
+  const [count, setCount] = useState(0)
+  return <button>Count: {count}</button>
+}
+`
+      )
+
+      const togglePath = path.join(tempDir, 'Toggle.tsx')
+      fs.writeFileSync(
+        togglePath,
+        `'use client'
+import { useState } from 'hono/jsx'
+export default function Toggle() {
+  const [on, setOn] = useState(false)
+  return <button>{on ? 'ON' : 'OFF'}</button>
+}
+`
+      )
+
+      // Create a page that uses both
+      const pagePath = path.join(tempDir, 'MultiClientPage.tsx')
+      fs.writeFileSync(
+        pagePath,
+        `'use client'
+import { useState } from 'hono/jsx'
+export default function MultiClientPage() {
+  const [value, setValue] = useState('')
+  return <input value={value} onChange={(e) => setValue(e.target.value)} />
+}
+`
+      )
+
+      try {
+        const app = new Hono()
+        const tracker = createManifestTracker(tempDir)
+
+        const manifest = createManifest(
+          [createRouteEntry('/multi', 'MultiClientPage.tsx', pagePath)],
+          tempDir
+        )
+
+        await registerRoutes(
+          app,
+          manifest,
+          createScanResult(),
+          mockLogger,
+          false,
+          tracker
+        )
+
+        // The page itself is tracked
+        expect(tracker.components.has(pagePath)).toBe(true)
+        expect(tracker.components.get(pagePath)?.componentId).toBe('MultiClientPage')
+      } finally {
+        // Cleanup
+        for (const p of [counterPath, togglePath, pagePath]) {
+          if (fs.existsSync(p)) fs.unlinkSync(p)
+        }
+      }
+    })
+  })
+})

--- a/packages/cli/src/server/hydrationRoutes.ts
+++ b/packages/cli/src/server/hydrationRoutes.ts
@@ -1,0 +1,177 @@
+/**
+ * @cloudwerk/cli - Hydration Routes
+ *
+ * Serves client-side hydration bundles:
+ * - /__cloudwerk/runtime.js - Hono JSX hydration runtime
+ * - /__cloudwerk/react-runtime.js - React hydration runtime
+ * - /__cloudwerk/:componentId.js - Individual component bundles
+ */
+
+import type { Hono } from 'hono'
+import {
+  generateHydrationRuntime,
+  generateReactHydrationRuntime,
+} from '@cloudwerk/ui'
+import { generateBundleOnDemand } from './clientBundle.js'
+import type { HydrationManifestTracker } from './hydrationManifest.js'
+import { getComponentByIdFromTracker } from './hydrationManifest.js'
+import type { Logger } from '../types.js'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Options for registering hydration routes.
+ */
+export interface HydrationRoutesOptions {
+  /** Hydration manifest tracker */
+  tracker: HydrationManifestTracker
+  /** App directory for component ID generation */
+  appDir: string
+  /** Logger for output */
+  logger: Logger
+  /** Enable verbose logging */
+  verbose?: boolean
+  /** Renderer type for determining which runtime to use */
+  renderer?: 'hono-jsx' | 'react'
+}
+
+// ============================================================================
+// Runtime Cache
+// ============================================================================
+
+/**
+ * Cache for generated runtime bundles.
+ * These don't change during a dev session, so we can cache them.
+ */
+const runtimeCache = new Map<string, string>()
+
+// ============================================================================
+// Route Registration
+// ============================================================================
+
+/**
+ * Register hydration routes with the Hono app.
+ *
+ * This registers the following routes BEFORE other routes:
+ * - GET /__cloudwerk/runtime.js - Hono JSX hydration runtime
+ * - GET /__cloudwerk/react-runtime.js - React hydration runtime
+ * - GET /__cloudwerk/:componentId.js - Individual component bundles
+ *
+ * @param app - Hono app instance
+ * @param options - Hydration route options
+ *
+ * @example
+ * ```typescript
+ * const tracker = createManifestTracker(appDir)
+ * registerHydrationRoutes(app, {
+ *   tracker,
+ *   appDir,
+ *   logger,
+ *   verbose: true,
+ * })
+ * ```
+ */
+export function registerHydrationRoutes(
+  app: Hono,
+  options: HydrationRoutesOptions
+): void {
+  const { tracker, appDir, logger, verbose = false, renderer = 'hono-jsx' } = options
+
+  // Register Hono JSX runtime route
+  app.get('/__cloudwerk/runtime.js', (c) => {
+    if (verbose) {
+      logger.debug('Serving Hono JSX hydration runtime')
+    }
+
+    // Check cache first
+    let runtime = runtimeCache.get('hono-jsx')
+    if (!runtime) {
+      runtime = generateHydrationRuntime()
+      runtimeCache.set('hono-jsx', runtime)
+    }
+
+    return c.text(runtime, 200, {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    })
+  })
+
+  // Register React runtime route
+  app.get('/__cloudwerk/react-runtime.js', (c) => {
+    if (verbose) {
+      logger.debug('Serving React hydration runtime')
+    }
+
+    // Check cache first
+    let runtime = runtimeCache.get('react')
+    if (!runtime) {
+      runtime = generateReactHydrationRuntime()
+      runtimeCache.set('react', runtime)
+    }
+
+    return c.text(runtime, 200, {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    })
+  })
+
+  // Register component bundle route
+  // Note: The :componentId param doesn't include .js extension
+  app.get('/__cloudwerk/:componentId{.+\\.js$}', async (c) => {
+    const componentIdWithExt = c.req.param('componentId')
+    // Remove .js extension to get component ID
+    const componentId = componentIdWithExt.replace(/\.js$/, '')
+
+    if (verbose) {
+      logger.debug(`Serving component bundle: ${componentId}`)
+    }
+
+    // Look up component in tracker
+    const component = getComponentByIdFromTracker(tracker, componentId)
+
+    if (!component) {
+      logger.warn(`[Cloudwerk] Component not found: ${componentId}`)
+      return c.text(`// Component not found: ${componentId}`, 404, {
+        'Content-Type': 'application/javascript; charset=utf-8',
+      })
+    }
+
+    try {
+      // Generate bundle on-demand
+      const { content } = await generateBundleOnDemand(
+        component.filePath,
+        appDir,
+        { renderer }
+      )
+
+      return c.text(content, 200, {
+        'Content-Type': 'application/javascript; charset=utf-8',
+        'Cache-Control': 'no-cache', // Dev mode - always check for updates
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error(`[Cloudwerk] Failed to bundle component ${componentId}: ${message}`)
+      return c.text(`// Bundle error: ${message}`, 500, {
+        'Content-Type': 'application/javascript; charset=utf-8',
+      })
+    }
+  })
+
+  if (verbose) {
+    logger.info('Registered hydration routes at /__cloudwerk/*')
+  }
+}
+
+// ============================================================================
+// Cache Management
+// ============================================================================
+
+/**
+ * Clear the runtime cache.
+ * Call this when runtimes need to be regenerated.
+ */
+export function clearRuntimeCache(): void {
+  runtimeCache.clear()
+}


### PR DESCRIPTION
## Summary

Wire the existing hydration infrastructure into the rendering pipeline so that components marked with `'use client'` directive are hydrated on the client side, making them interactive.

- Add hydration routes to serve client bundles at `/__cloudwerk/*`
- Track client components during page and layout loading
- Inject preload hints and hydration scripts into HTML responses
- Support both Hono JSX and React renderers

## Changes

### New Files
- `packages/cli/src/server/hydrationRoutes.ts` - Route handlers for serving client bundles
- `packages/cli/src/server/__tests__/hydrationRoutes.test.ts` - Tests for hydration routes (10 tests)
- `packages/cli/src/server/__tests__/registerRoutes.hydration.test.ts` - Integration tests (5 tests)

### Modified Files
- `packages/cli/src/server/createApp.ts` - Creates hydration tracker, registers hydration routes before other routes
- `packages/cli/src/server/registerRoutes.ts` - Tracks client components during loading, injects hydration scripts

## Technical Approach

The implementation leverages existing hydration utilities that were already present in the codebase:
- `@cloudwerk/ui`: `generateHydrationScript()`, `generatePreloadHints()`, `generateHydrationRuntime()`
- `@cloudwerk/cli`: `generateBundleOnDemand()`, `createManifestTracker()`, `trackIfClientComponent()`

These utilities were wired into the rendering flow at key integration points.

## Test Plan

- [x] Build passes (`pnpm build`)
- [x] All 219 tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] TypeScript check passes
- [ ] Counter component in `template-hono-jsx` is interactive
- [ ] HTML output contains hydration attributes and scripts
- [ ] Client bundles served at `/__cloudwerk/*`

## Known Limitations

- **Hono JSX re-render flash**: The hydration uses `render()` from `hono/jsx/dom` which replaces content rather than true hydration. This may cause a brief visual flash.
- **Streaming with hydration**: For pages with client components, the response is buffered to inject hydration scripts.

## Related Issues

Closes #133