### PR TITLE
fix: release unpublished hydration utilities and add CI validation

### DIFF
--- a/.changeset/release-hydration-utils.md
+++ b/.changeset/release-hydration-utils.md
@@ -1,0 +1,23 @@
+---
+"@cloudwerk/core": minor
+"@cloudwerk/ui": minor
+---
+
+feat: release hydration utilities
+
+Release previously implemented but unpublished hydration utilities:
+
+**@cloudwerk/core:**
+- `hasUseClientDirective()` - Detect 'use client' directive
+- `generateComponentId()` - Generate unique component IDs
+- `createHydrationManifest()` / `addToHydrationManifest()` - Manifest creation
+- `serializeProps()` / `deserializeProps()` - Props serialization for hydration
+- `ClientComponentInfo`, `ClientComponentMeta`, `HydrationManifest` types
+
+**@cloudwerk/ui:**
+- `wrapForHydration()` - Wrap components with hydration metadata
+- `generateHydrationScript()` / `generateReactHydrationScript()` - Bootstrap scripts
+- `generatePreloadHints()` - Preload hints generation
+- `generateHydrationRuntime()` / `generateReactHydrationRuntime()` - Runtime code
+
+These utilities are required by @cloudwerk/cli@0.5.0 for client component hydration.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate changesets
+        if: github.event_name == 'pull_request'
+        run: npx tsx scripts/validate-changesets.ts
+
+      - name: Validate cross-package imports
+        run: npx tsx scripts/validate-cross-package-imports.ts
+
       - name: Build packages
         run: pnpm build
 

--- a/scripts/validate-changesets.ts
+++ b/scripts/validate-changesets.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env npx tsx
+/**
+ * Validate that all modified packages have corresponding changesets.
+ *
+ * This script:
+ * 1. Detects which packages have changes (vs main branch)
+ * 2. Reads all changeset files
+ * 3. Ensures every changed package is mentioned in at least one changeset
+ *
+ * Run: npx tsx scripts/validate-changesets.ts
+ */
+
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+// ANSI colors
+const RED = '\x1b[31m'
+const GREEN = '\x1b[32m'
+const YELLOW = '\x1b[33m'
+const RESET = '\x1b[0m'
+
+// Packages to check
+const PACKAGES = [
+  { name: '@cloudwerk/core', path: 'packages/core' },
+  { name: '@cloudwerk/ui', path: 'packages/ui' },
+  { name: '@cloudwerk/cli', path: 'packages/cli' },
+  { name: '@cloudwerk/create-app', path: 'apps/create-cloudwerk-app' },
+]
+
+// Files that don't require changesets
+const IGNORED_PATTERNS = [
+  /\.test\.ts$/,
+  /\.test\.tsx$/,
+  /\.spec\.ts$/,
+  /__tests__\//,
+  /__fixtures__\//,
+  /\.md$/,
+  /\.json$/, // package.json changes handled by changesets
+]
+
+function runGit(args: string[]): string {
+  const result = spawnSync('git', args, { encoding: 'utf-8' })
+  if (result.error) {
+    throw result.error
+  }
+  return result.stdout || ''
+}
+
+function getChangedFiles(): string[] {
+  try {
+    // Get changes compared to main branch
+    const diff = runGit(['diff', '--name-only', 'origin/main...HEAD'])
+    return diff.trim().split('\n').filter(Boolean)
+  } catch {
+    // Fallback: check uncommitted changes
+    const diff = runGit(['diff', '--name-only', 'HEAD'])
+    return diff.trim().split('\n').filter(Boolean)
+  }
+}
+
+function getChangedPackages(changedFiles: string[]): Set<string> {
+  const changedPackages = new Set<string>()
+
+  for (const file of changedFiles) {
+    // Skip ignored patterns
+    if (IGNORED_PATTERNS.some((pattern) => pattern.test(file))) {
+      continue
+    }
+
+    // Check which package this file belongs to
+    for (const pkg of PACKAGES) {
+      if (file.startsWith(pkg.path + '/')) {
+        changedPackages.add(pkg.name)
+        break
+      }
+    }
+  }
+
+  return changedPackages
+}
+
+function getPackagesInChangesets(): Set<string> {
+  const changesetDir = path.join(process.cwd(), '.changeset')
+  const packagesInChangesets = new Set<string>()
+
+  if (!fs.existsSync(changesetDir)) {
+    return packagesInChangesets
+  }
+
+  const files = fs.readdirSync(changesetDir)
+
+  for (const file of files) {
+    if (!file.endsWith('.md') || file === 'README.md' || file === 'config.json') {
+      continue
+    }
+
+    const content = fs.readFileSync(path.join(changesetDir, file), 'utf-8')
+
+    // Parse YAML frontmatter to find package names
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+    if (frontmatterMatch) {
+      const frontmatter = frontmatterMatch[1]
+      // Match package names in quotes
+      const packageMatches = frontmatter.matchAll(/"(@cloudwerk\/[^"]+)":/g)
+      for (const match of packageMatches) {
+        packagesInChangesets.add(match[1])
+      }
+    }
+  }
+
+  return packagesInChangesets
+}
+
+function main() {
+  console.log('Validating changesets...\n')
+
+  // Get changed files
+  const changedFiles = getChangedFiles()
+  if (changedFiles.length === 0) {
+    console.log(`${GREEN}✓${RESET} No changed files detected`)
+    process.exit(0)
+  }
+
+  console.log(`Found ${changedFiles.length} changed files`)
+
+  // Get changed packages
+  const changedPackages = getChangedPackages(changedFiles)
+  if (changedPackages.size === 0) {
+    console.log(`${GREEN}✓${RESET} No packages with meaningful changes`)
+    process.exit(0)
+  }
+
+  console.log(`Changed packages: ${Array.from(changedPackages).join(', ')}\n`)
+
+  // Get packages mentioned in changesets
+  const packagesInChangesets = getPackagesInChangesets()
+  console.log(
+    `Packages in changesets: ${Array.from(packagesInChangesets).join(', ') || '(none)'}\n`
+  )
+
+  // Find missing changesets
+  const missingChangesets: string[] = []
+  for (const pkg of changedPackages) {
+    if (!packagesInChangesets.has(pkg)) {
+      missingChangesets.push(pkg)
+    }
+  }
+
+  if (missingChangesets.length > 0) {
+    console.log(`${RED}✗${RESET} Missing changesets for:`)
+    for (const pkg of missingChangesets) {
+      console.log(`  - ${pkg}`)
+    }
+    console.log(`\n${YELLOW}Run 'pnpm changeset' to add a changeset for these packages${RESET}`)
+    process.exit(1)
+  }
+
+  console.log(`${GREEN}✓${RESET} All changed packages have changesets`)
+  process.exit(0)
+}
+
+main()

--- a/scripts/validate-cross-package-imports.ts
+++ b/scripts/validate-cross-package-imports.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env npx tsx
+/**
+ * Validate that all cross-package imports are properly exported.
+ *
+ * This script:
+ * 1. Finds all imports from @cloudwerk/* packages
+ * 2. Checks that those imports exist in the package's exports
+ * 3. Reports any imports that don't exist (would fail at runtime with published packages)
+ *
+ * Run: npx tsx scripts/validate-cross-package-imports.ts
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+// ANSI colors
+const RED = '\x1b[31m'
+const GREEN = '\x1b[32m'
+const YELLOW = '\x1b[33m'
+const CYAN = '\x1b[36m'
+const RESET = '\x1b[0m'
+
+// Package configurations
+const PACKAGES: Record<string, { path: string; entryPoint: string }> = {
+  '@cloudwerk/core': {
+    path: 'packages/core',
+    entryPoint: 'packages/core/src/index.ts',
+  },
+  '@cloudwerk/ui': {
+    path: 'packages/ui',
+    entryPoint: 'packages/ui/src/index.ts',
+  },
+  '@cloudwerk/cli': {
+    path: 'packages/cli',
+    entryPoint: 'packages/cli/src/index.ts',
+  },
+}
+
+// Cache for package exports
+const exportCache = new Map<string, Set<string>>()
+
+/**
+ * Get all exports from a package's entry point.
+ */
+function getPackageExports(packageName: string): Set<string> {
+  if (exportCache.has(packageName)) {
+    return exportCache.get(packageName)!
+  }
+
+  const config = PACKAGES[packageName]
+  if (!config) {
+    return new Set()
+  }
+
+  const entryPath = path.join(process.cwd(), config.entryPoint)
+  if (!fs.existsSync(entryPath)) {
+    console.warn(`${YELLOW}Warning: Entry point not found: ${entryPath}${RESET}`)
+    return new Set()
+  }
+
+  let content = fs.readFileSync(entryPath, 'utf-8')
+
+  // Remove single-line comments to avoid parsing issues
+  content = content.replace(/\/\/[^\n]*/g, '')
+  // Remove multi-line comments
+  content = content.replace(/\/\*[\s\S]*?\*\//g, '')
+
+  const exports = new Set<string>()
+
+  // Match named exports: export { foo, bar } from '...'
+  const namedExportMatches = content.matchAll(
+    /export\s*\{([^}]+)\}\s*from/g
+  )
+  for (const match of namedExportMatches) {
+    const names = match[1]
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0)
+      .map((n) => {
+        // Handle "foo as bar" syntax - take the exported name (bar)
+        const parts = n.split(/\s+as\s+/)
+        return parts[parts.length - 1].trim()
+      })
+    for (const name of names) {
+      if (name && /^\w+$/.test(name)) exports.add(name)
+    }
+  }
+
+  // Match type exports: export type { Foo } from '...'
+  const typeExportMatches = content.matchAll(
+    /export\s+type\s*\{([^}]+)\}\s*from/g
+  )
+  for (const match of typeExportMatches) {
+    const names = match[1]
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0)
+      .map((n) => {
+        const parts = n.split(/\s+as\s+/)
+        return parts[parts.length - 1].trim()
+      })
+    for (const name of names) {
+      if (name && /^\w+$/.test(name)) exports.add(name)
+    }
+  }
+
+  // Match direct exports: export function foo, export const bar, export class Baz
+  const directExportMatches = content.matchAll(
+    /export\s+(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+(\w+)/g
+  )
+  for (const match of directExportMatches) {
+    exports.add(match[1])
+  }
+
+  // Match default export
+  if (/export\s+default/.test(content)) {
+    exports.add('default')
+  }
+
+  exportCache.set(packageName, exports)
+  return exports
+}
+
+interface ImportIssue {
+  file: string
+  line: number
+  packageName: string
+  importedNames: string[]
+  missingNames: string[]
+}
+
+/**
+ * Determine which package a file belongs to.
+ */
+function getFilePackage(filePath: string): string | null {
+  for (const [packageName, config] of Object.entries(PACKAGES)) {
+    const packageDir = path.join(process.cwd(), config.path)
+    if (filePath.startsWith(packageDir)) {
+      return packageName
+    }
+  }
+  return null
+}
+
+/**
+ * Find all cross-package imports in a file.
+ */
+function findCrossPackageImports(filePath: string): ImportIssue[] {
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const lines = content.split('\n')
+  const issues: ImportIssue[] = []
+
+  // Get the package this file belongs to
+  const sourcePackage = getFilePackage(filePath)
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Match imports from @cloudwerk packages
+    // import { foo, bar } from '@cloudwerk/core'
+    // import type { Foo } from '@cloudwerk/core'
+    const importMatch = line.match(
+      /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"](@cloudwerk\/[^'"]+)['"]/
+    )
+
+    if (importMatch) {
+      const importedNames = importMatch[1]
+        .split(',')
+        .map((n) => {
+          // Handle "foo as bar" syntax - take the imported name (foo)
+          const parts = n.trim().split(/\s+as\s+/)
+          return parts[0].trim()
+        })
+        .filter(Boolean)
+
+      const packageName = importMatch[2]
+
+      // Skip if not a known package
+      if (!PACKAGES[packageName]) {
+        continue
+      }
+
+      // Skip if importing from the same package (internal imports are fine)
+      if (packageName === sourcePackage) {
+        continue
+      }
+
+      // Get package exports
+      const packageExports = getPackageExports(packageName)
+
+      // Find missing exports
+      const missingNames = importedNames.filter((name) => !packageExports.has(name))
+
+      if (missingNames.length > 0) {
+        issues.push({
+          file: filePath,
+          line: i + 1,
+          packageName,
+          importedNames,
+          missingNames,
+        })
+      }
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Recursively find all TypeScript files in a directory.
+ */
+function findTypeScriptFiles(dir: string): string[] {
+  const files: string[] = []
+
+  if (!fs.existsSync(dir)) {
+    return files
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      // Skip node_modules, dist, etc.
+      if (['node_modules', 'dist', '.git', 'coverage'].includes(entry.name)) {
+        continue
+      }
+      files.push(...findTypeScriptFiles(fullPath))
+    } else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+function main() {
+  console.log('Validating cross-package imports...\n')
+
+  const allIssues: ImportIssue[] = []
+
+  // Check each package
+  for (const [packageName, config] of Object.entries(PACKAGES)) {
+    const srcDir = path.join(process.cwd(), config.path, 'src')
+    const files = findTypeScriptFiles(srcDir)
+
+    console.log(`Checking ${CYAN}${packageName}${RESET} (${files.length} files)`)
+
+    for (const file of files) {
+      const issues = findCrossPackageImports(file)
+      allIssues.push(...issues)
+    }
+  }
+
+  console.log()
+
+  if (allIssues.length === 0) {
+    console.log(`${GREEN}✓${RESET} All cross-package imports are valid`)
+    process.exit(0)
+  }
+
+  console.log(`${RED}✗${RESET} Found ${allIssues.length} import issues:\n`)
+
+  for (const issue of allIssues) {
+    const relativePath = path.relative(process.cwd(), issue.file)
+    console.log(`${CYAN}${relativePath}:${issue.line}${RESET}`)
+    console.log(`  Package: ${issue.packageName}`)
+    console.log(`  Missing exports: ${RED}${issue.missingNames.join(', ')}${RESET}`)
+    console.log()
+  }
+
+  console.log(
+    `${YELLOW}These imports will fail at runtime when using published packages.${RESET}`
+  )
+  console.log(
+    `${YELLOW}Ensure these exports are added to the package's index.ts and included in a changeset.${RESET}`
+  )
+
+  process.exit(1)
+}
+
+main()


### PR DESCRIPTION
## Problem

The `@cloudwerk/cli@0.5.0` published package imports from `@cloudwerk/core` exports that don't exist in the published `@cloudwerk/core@0.3.0`:

```
SyntaxError: The requested module '@cloudwerk/core' does not provide an export named 'addToHydrationManifest'
```

This happened because:
1. Hydration utilities were added to core/ui in a previous PR
2. That PR didn't include a changeset for core/ui
3. Only CLI was bumped and published
4. CLI now depends on exports that don't exist in published core

## Solution

### 1. Release Missing Exports

Add changeset to bump `@cloudwerk/core` and `@cloudwerk/ui` with their hydration utilities:

**@cloudwerk/core:**
- `hasUseClientDirective()`, `generateComponentId()`
- `createHydrationManifest()`, `addToHydrationManifest()`
- `serializeProps()`, `deserializeProps()`
- Related types

**@cloudwerk/ui:**
- `wrapForHydration()`
- `generateHydrationScript()`, `generateReactHydrationScript()`
- `generatePreloadHints()`
- `generateHydrationRuntime()`, `generateReactHydrationRuntime()`

### 2. Add CI Automation

Add two validation scripts to prevent this issue:

**`scripts/validate-changesets.ts`**
- Runs on PRs in CI
- Detects which packages have source changes
- Fails if changed packages don't have corresponding changesets

**`scripts/validate-cross-package-imports.ts`**
- Runs on every CI build
- Validates that imports between `@cloudwerk/*` packages are properly exported
- Catches cases where code imports something that exists locally but isn't published

## Test Plan

- [x] `validate-cross-package-imports.ts` passes locally
- [x] `validate-changesets.ts` passes locally
- [ ] CI runs validation scripts
- [ ] After merge, changesets releases core and ui
- [ ] New projects can run `pnpm dlx @cloudwerk/create-app` successfully