### PR TITLE
Add README files to published packages

### DIFF
--- a/.changeset/add-package-readmes.md
+++ b/.changeset/add-package-readmes.md
@@ -1,0 +1,9 @@
+---
+"@cloudwerk/core": patch
+"@cloudwerk/cli": patch
+"@cloudwerk/ui": patch
+"@cloudwerk/vite-plugin": patch
+"@cloudwerk/utils": patch
+---
+
+Add README files to all published packages for npm display

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,74 @@
+# @cloudwerk/cli
+
+Command-line tool for developing and building Cloudwerk applications.
+
+## Installation
+
+```bash
+npm install @cloudwerk/cli
+```
+
+## Commands
+
+### Development Server
+
+Start the dev server with hot reload:
+
+```bash
+cloudwerk dev
+```
+
+Options:
+- `-p, --port <number>` - Port to listen on (default: 3000)
+- `-H, --host <host>` - Host to bind (default: localhost)
+- `-c, --config <path>` - Path to config file
+- `--verbose` - Enable verbose logging
+
+### Production Build
+
+Build for deployment to Cloudflare Workers:
+
+```bash
+cloudwerk build
+```
+
+Options:
+- `-o, --output <dir>` - Output directory (default: ./dist)
+- `--ssg` - Generate static pages for routes with `rendering: 'static'`
+- `--minify` / `--no-minify` - Toggle minification (default: enabled)
+- `--sourcemap` - Generate source maps
+- `-c, --config <path>` - Path to config file
+- `--verbose` - Enable verbose logging
+
+### Configuration
+
+Manage configuration values:
+
+```bash
+cloudwerk config get <key>
+cloudwerk config set <key> <value>
+```
+
+## Quick Start
+
+```bash
+# Create a new project
+mkdir my-app && cd my-app
+npm init -y
+npm install @cloudwerk/cli
+
+# Create a simple page
+mkdir -p app/routes
+echo 'export default () => <h1>Hello Cloudwerk!</h1>' > app/routes/page.tsx
+
+# Start development
+npx cloudwerk dev
+```
+
+## Documentation
+
+For full documentation, visit: https://github.com/squirrelsoft-dev/cloudwerk
+
+## Part of Cloudwerk
+
+This package is part of the [Cloudwerk](https://github.com/squirrelsoft-dev/cloudwerk) monorepo.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,77 @@
+# @cloudwerk/core
+
+Core routing, middleware, and configuration for Cloudwerk - a full-stack framework for Cloudflare Workers.
+
+## Installation
+
+```bash
+npm install @cloudwerk/core
+```
+
+## Entry Points
+
+This package provides two entry points optimized for different use cases:
+
+### `@cloudwerk/core/runtime`
+
+Runtime-only exports for Cloudflare Workers. Excludes build-time dependencies to minimize bundle size.
+
+```typescript
+import {
+  // Response helpers
+  json, created, noContent, redirect, html, text,
+  notFoundResponse, badRequest, unauthorized, forbidden,
+
+  // Context and middleware
+  getContext, createMiddlewareAdapter,
+
+  // Errors
+  NotFoundError, RedirectError, notFound,
+
+  // Types
+  type CloudwerkHandler, type CloudwerkHandlerContext,
+  type PageProps, type LayoutProps, type LoaderArgs
+} from '@cloudwerk/core/runtime'
+```
+
+### `@cloudwerk/core/build`
+
+Build-time exports for CLI and tooling. Includes filesystem dependencies (fast-glob, esbuild).
+
+```typescript
+import {
+  // Route compilation
+  buildRouteManifest, scanRoutes, compileRoute,
+
+  // Configuration
+  loadConfig, defineConfig, DEFAULT_CONFIG,
+
+  // Validation
+  validateManifest, validateRoute,
+
+  // Types
+  type RouteManifest, type CloudwerkConfig
+} from '@cloudwerk/core/build'
+```
+
+## Basic Usage
+
+```typescript
+// app/routes/users/[id]/route.ts
+import { json, notFoundResponse } from '@cloudwerk/core/runtime'
+import type { CloudwerkHandler } from '@cloudwerk/core/runtime'
+
+export const GET: CloudwerkHandler = async (request, { params }) => {
+  const user = await getUser(params.id)
+  if (!user) return notFoundResponse()
+  return json(user)
+}
+```
+
+## Documentation
+
+For full documentation, visit: https://github.com/squirrelsoft-dev/cloudwerk
+
+## Part of Cloudwerk
+
+This package is part of the [Cloudwerk](https://github.com/squirrelsoft-dev/cloudwerk) monorepo.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,80 @@
+# @cloudwerk/ui
+
+UI rendering abstraction for Cloudwerk. Supports Hono JSX (default) and React.
+
+## Installation
+
+```bash
+npm install @cloudwerk/ui
+```
+
+For React support:
+```bash
+npm install @cloudwerk/ui react react-dom
+```
+
+## Key Exports
+
+```typescript
+import {
+  // Rendering
+  render,    // Render JSX to Response
+  html,      // Create HTML Response from string
+  hydrate,   // Client-side hydration
+
+  // Renderer management
+  setActiveRenderer,
+  initReactRenderer,
+
+  // Hydration utilities
+  wrapForHydration,
+  generateHydrationScript
+} from '@cloudwerk/ui'
+```
+
+## Basic Usage
+
+```typescript
+// Render a JSX component
+import { render } from '@cloudwerk/ui'
+
+export function GET() {
+  return render(<HomePage />)
+}
+
+// With options
+return render(<NotFoundPage />, { status: 404 })
+
+// Raw HTML response
+import { html } from '@cloudwerk/ui'
+
+return html('<!DOCTYPE html><html><body>Hello</body></html>')
+```
+
+## React Renderer
+
+To use React instead of Hono JSX:
+
+```typescript
+import { initReactRenderer, setActiveRenderer } from '@cloudwerk/ui'
+
+// Register and activate React renderer
+initReactRenderer()
+setActiveRenderer('react')
+```
+
+## Client Entry Point
+
+For client-side hydration, import from the client subpath:
+
+```typescript
+import { hydrate } from '@cloudwerk/ui/client'
+```
+
+## Documentation
+
+For full documentation, visit: https://github.com/squirrelsoft-dev/cloudwerk
+
+## Part of Cloudwerk
+
+This package is part of the [Cloudwerk](https://github.com/squirrelsoft-dev/cloudwerk) monorepo.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,60 @@
+# @cloudwerk/utils
+
+Browser-safe utilities for Cloudwerk. Zero dependencies, works in both server and browser environments.
+
+## Installation
+
+```bash
+npm install @cloudwerk/utils
+```
+
+## Exports
+
+```typescript
+import {
+  serializeProps,
+  deserializeProps,
+  escapeHtmlAttribute
+} from '@cloudwerk/utils'
+```
+
+## API
+
+### `serializeProps(props: unknown): string`
+
+Serialize props to a JSON string for embedding in HTML attributes.
+
+```typescript
+const serialized = serializeProps({ user: { name: 'Alice' } })
+// '{"user":{"name":"Alice"}}'
+```
+
+### `deserializeProps<T>(value: string): T`
+
+Deserialize props from a JSON string.
+
+```typescript
+const props = deserializeProps<{ user: { name: string } }>(serialized)
+// { user: { name: 'Alice' } }
+```
+
+### `escapeHtmlAttribute(value: string): string`
+
+Escape a string for safe use in HTML attributes.
+
+```typescript
+const safe = escapeHtmlAttribute('Hello "World"')
+// 'Hello &quot;World&quot;'
+```
+
+## Use Case
+
+These utilities are primarily used internally by `@cloudwerk/ui` for client component hydration, but are available for direct use when building custom rendering solutions.
+
+## Documentation
+
+For full documentation, visit: https://github.com/squirrelsoft-dev/cloudwerk
+
+## Part of Cloudwerk
+
+This package is part of the [Cloudwerk](https://github.com/squirrelsoft-dev/cloudwerk) monorepo.

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,0 +1,66 @@
+# @cloudwerk/vite-plugin
+
+Vite plugin for Cloudwerk file-based routing with virtual entry generation.
+
+## Installation
+
+```bash
+npm install @cloudwerk/vite-plugin vite
+```
+
+## Setup
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite'
+import cloudwerk from '@cloudwerk/vite-plugin'
+
+export default defineConfig({
+  plugins: [
+    cloudwerk({
+      // Options (all optional)
+      appDir: 'app',        // Directory containing app files
+      routesDir: 'routes',  // Subdirectory for routes
+      renderer: 'hono-jsx', // 'hono-jsx' or 'react'
+      verbose: false,       // Enable debug logging
+    })
+  ]
+})
+```
+
+## Virtual Modules
+
+The plugin generates virtual modules for your application:
+
+| Module | Description |
+|--------|-------------|
+| `virtual:cloudwerk/server-entry` | Server entry with route registration |
+| `virtual:cloudwerk/client-entry` | Client entry for hydration |
+| `virtual:cloudwerk/manifest` | Compiled route manifest |
+
+Import in your code:
+
+```typescript
+import app from 'virtual:cloudwerk/server-entry'
+import manifest from 'virtual:cloudwerk/manifest'
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `appDir` | `string` | `'app'` | Directory containing route files |
+| `routesDir` | `string` | `'routes'` | Subdirectory within appDir for routes |
+| `config` | `object` | - | Override Cloudwerk configuration |
+| `serverEntry` | `string` | - | Custom server entry file path |
+| `clientEntry` | `string` | - | Custom client entry file path |
+| `renderer` | `string` | `'hono-jsx'` | UI renderer (`'hono-jsx'` or `'react'`) |
+| `verbose` | `boolean` | `false` | Enable verbose logging |
+
+## Documentation
+
+For full documentation, visit: https://github.com/squirrelsoft-dev/cloudwerk
+
+## Part of Cloudwerk
+
+This package is part of the [Cloudwerk](https://github.com/squirrelsoft-dev/cloudwerk) monorepo.


### PR DESCRIPTION
## Summary
- Add README.md files to all 5 published packages (@cloudwerk/core, @cloudwerk/cli, @cloudwerk/ui, @cloudwerk/vite-plugin, @cloudwerk/utils)
- Each README includes installation, key exports, basic usage examples, and links to documentation
- READMEs will now display properly on npm package pages

## Test plan
- [x] Verified `pnpm build` passes
- [x] Verified README is included in package via `npm pack --dry-run`