### PR TITLE
feat(cli): improve bindings command with multi-account support and env handling

### DIFF
--- a/apps/create-cloudwerk-app/template-api/package.json.tmpl
+++ b/apps/create-cloudwerk-app/template-api/package.json.tmpl
@@ -8,7 +8,8 @@
     "build": "cloudwerk build",
     "preview": "cloudwerk deploy --env preview",
     "preview:teardown": "wrangler delete --env preview",
-    "deploy": "cloudwerk deploy"
+    "deploy": "cloudwerk deploy",
+    "bindings": "cloudwerk bindings"
   },
   "dependencies": {
     "@cloudwerk/core": "^{{coreVersion}}",

--- a/apps/create-cloudwerk-app/template-hono-jsx/package.json.tmpl
+++ b/apps/create-cloudwerk-app/template-hono-jsx/package.json.tmpl
@@ -8,7 +8,8 @@
     "build": "cloudwerk build",
     "preview": "cloudwerk deploy --env preview",
     "preview:teardown": "wrangler delete --env preview",
-    "deploy": "cloudwerk deploy"
+    "deploy": "cloudwerk deploy",
+    "bindings": "cloudwerk bindings"
   },
   "dependencies": {
     "@cloudwerk/core": "^{{coreVersion}}",

--- a/apps/create-cloudwerk-app/template-react/package.json.tmpl
+++ b/apps/create-cloudwerk-app/template-react/package.json.tmpl
@@ -8,7 +8,8 @@
     "build": "cloudwerk build",
     "preview": "cloudwerk deploy --env preview",
     "preview:teardown": "wrangler delete --env preview",
-    "deploy": "cloudwerk deploy"
+    "deploy": "cloudwerk deploy",
+    "bindings": "cloudwerk bindings"
   },
   "dependencies": {
     "@cloudwerk/core": "^{{coreVersion}}",

--- a/apps/test-hydration/.gitignore
+++ b/apps/test-hydration/.gitignore
@@ -1,0 +1,5 @@
+# Local wrangler config with account-specific IDs
+wrangler.toml
+
+# Generated type definitions
+env.d.ts

--- a/apps/test-hydration/package.json
+++ b/apps/test-hydration/package.json
@@ -8,7 +8,8 @@
     "test-build": "cloudwerk build",
     "preview": "cloudwerk deploy --env preview",
     "preview:teardown": "wrangler delete --env preview",
-    "deploy": "cloudwerk deploy"
+    "deploy": "cloudwerk deploy",
+    "bindings": "cloudwerk bindings"
   },
   "dependencies": {
     "@cloudwerk/core": "workspace:*",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ program
   .name('cloudwerk')
   .description('Cloudwerk CLI - Build and deploy full-stack apps to Cloudflare')
   .version(VERSION)
+  .enablePositionalOptions()
 
 // ============================================================================
 // Dev Command
@@ -97,7 +98,8 @@ configCmd
 const bindingsCmd = program
   .command('bindings')
   .description('Manage Cloudflare bindings (D1, KV, R2, Queues, etc.)')
-  .option('-e, --env <environment>', 'Environment to operate on')
+  .enablePositionalOptions()
+  .passThroughOptions()
   .option('--verbose', 'Enable verbose logging')
   .action(bindings)
 


### PR DESCRIPTION
## Summary

- Add interactive Cloudflare account selection when multiple accounts are available (parses error, prompts user, saves `account_id` to wrangler.toml)
- Fix `--env` option not being passed to subcommands by configuring commander.js with `enablePositionalOptions()` and `passThroughOptions()`
- Fix `bindingExists` to only check bindings in the target environment, allowing same binding name in base and env configs (e.g., `DB` in both production and preview pointing to different databases)
- Update resource name generation to put env before suffix (`test-hydration-preview-db` instead of `test-hydration-db-preview`)
- Add `bindings` script to all template package.json files for `pnpm bindings` command

## Test plan

- [ ] Run `pnpm bindings add` with multiple Cloudflare accounts and verify account selection prompt appears
- [ ] Run `pnpm bindings add --env preview` and verify `--env` is correctly passed
- [ ] Add same binding name (e.g., `DB`) to both base config and preview env
- [ ] Verify suggested resource names include env before suffix for non-production environments